### PR TITLE
Do not use https://doc.onlyoffice.com as example

### DIFF
--- a/web/documentserver-example/csharp-mvc/web.appsettings.config
+++ b/web/documentserver-example/csharp-mvc/web.appsettings.config
@@ -14,7 +14,7 @@
   <add key="files.docservice.convert-docs" value=".docm|.dotx|.dotm|.dot|.doc|.odt|.fodt|.xlsm|.xltx|.xltm|.xlt|.xls|.ods|.fods|.pptm|.ppt|.ppsm|.pps|.potx|.potm|.pot|.odp|.fodp|.rtf|.mht|.html|.htm|.epub"/>
   <add key="files.docservice.timeout" value="120000" />
 
-  <add key="files.docservice.url.converter" value="https://doc.onlyoffice.com/ConvertService.ashx"/>
-  <add key="files.docservice.url.api" value="https://doc.onlyoffice.com/web-apps/apps/api/documents/api.js"/>
-  <add key="files.docservice.url.preloader" value="https://doc.onlyoffice.com/web-apps/apps/api/documents/cache-scripts.html"/>
+  <add key="files.docservice.url.converter" value="http://documentserver/ConvertService.ashx"/>
+  <add key="files.docservice.url.api" value="http://documentserver/web-apps/apps/api/documents/api.js"/>
+  <add key="files.docservice.url.preloader" value="http://documentserver/web-apps/apps/api/documents/cache-scripts.html"/>
 </appSettings>

--- a/web/documentserver-example/csharp/settings.config
+++ b/web/documentserver-example/csharp/settings.config
@@ -10,7 +10,7 @@
   <add key="files.docservice.convert-docs" value=".docm|.dotx|.dotm|.dot|.doc|.odt|.fodt|.xlsm|.xltx|.xltm|.xlt|.xls|.ods|.fods|.pptm|.ppt|.ppsm|.pps|.potx|.potm|.pot|.odp|.fodp|.rtf|.mht|.html|.htm|.epub"/>
   <add key="files.docservice.timeout" value="120000" />
 
-  <add key="files.docservice.url.converter" value="https://doc.onlyoffice.com/ConvertService.ashx"/>
-  <add key="files.docservice.url.api" value="https://doc.onlyoffice.com/web-apps/apps/api/documents/api.js"/>
-  <add key="files.docservice.url.preloader" value="https://doc.onlyoffice.com/web-apps/apps/api/documents/cache-scripts.html"/>
+  <add key="files.docservice.url.converter" value="http://documentserver/ConvertService.ashx"/>
+  <add key="files.docservice.url.api" value="http://documentserver/web-apps/apps/api/documents/api.js"/>
+  <add key="files.docservice.url.preloader" value="http://documentserver/web-apps/apps/api/documents/cache-scripts.html"/>
 </appSettings>

--- a/web/documentserver-example/java/src/main/resources/settings.properties
+++ b/web/documentserver-example/java/src/main/resources/settings.properties
@@ -6,7 +6,7 @@ files.docservice.edited-docs=.docx|.xlsx|.csv|.pptx|.ppsx|.txt
 files.docservice.convert-docs=.docm|.dotx|.dotm|.dot|.doc|.odt|.fodt|.xlsm|.xltx|.xltm|.xlt|.xls|.ods|.fods|.pptm|.ppt|.ppsm|.pps|.potx|.potm|.pot|.odp|.fodp|.rtf|.mht|.html|.htm|.epub
 files.docservice.timeout=120000
 
-files.docservice.url.converter=https://doc.onlyoffice.com/ConvertService.ashx
-files.docservice.url.tempstorage=https://doc.onlyoffice.com/ResourceService.ashx
-files.docservice.url.api=https://doc.onlyoffice.com/web-apps/apps/api/documents/api.js
-files.docservice.url.preloader=https://doc.onlyoffice.com/web-apps/apps/api/documents/cache-scripts.html
+files.docservice.url.converter=http://documentserver/ConvertService.ashx
+files.docservice.url.tempstorage=http://documentserver/ResourceService.ashx
+files.docservice.url.api=http://documentserver/web-apps/apps/api/documents/api.js
+files.docservice.url.preloader=http://documentserver/web-apps/apps/api/documents/cache-scripts.html

--- a/web/documentserver-example/js/OnlineEditorsExampleJS.html
+++ b/web/documentserver-example/js/OnlineEditorsExampleJS.html
@@ -33,7 +33,7 @@
     <link href="stylesheet.css" type="text/css" rel="stylesheet">
 
     <!--Change the address on installed ONLYOFFICE Online Editors-->
-    <script id="scriptApi" type="text/javascript" src="https://doc.onlyoffice.com/web-apps/apps/api/documents/api.js"></script>
+    <script id="scriptApi" type="text/javascript" src="http://documentserver/web-apps/apps/api/documents/api.js"></script>
 
 
     <script type="text/javascript" src="init.js"></script>

--- a/web/documentserver-example/nodejs/config/default.json
+++ b/web/documentserver-example/nodejs/config/default.json
@@ -12,7 +12,7 @@
   },
   "server": {
     "port": 3000,
-    "siteUrl": "https://doc.onlyoffice.com/",
+    "siteUrl": "http://documentserver/",
     "commandUrl": "coauthoring/CommandService.ashx",
     "converterUrl": "ConvertService.ashx",
     "tempStorageUrl": "ResourceService.ashx",

--- a/web/documentserver-example/php/config.php
+++ b/web/documentserver-example/php/config.php
@@ -12,10 +12,10 @@ $GLOBALS['DOC_SERV_CONVERT'] = array(".docm", ".doc", ".dotx", ".dotm", ".dot", 
 
 $GLOBALS['DOC_SERV_TIMEOUT'] = "120000";
 
-$GLOBALS['DOC_SERV_CONVERTER_URL'] = "https://doc.onlyoffice.com/ConvertService.ashx";
-$GLOBALS['DOC_SERV_API_URL'] = "https://doc.onlyoffice.com/web-apps/apps/api/documents/api.js";
+$GLOBALS['DOC_SERV_CONVERTER_URL'] = "http://documentserver/ConvertService.ashx";
+$GLOBALS['DOC_SERV_API_URL'] = "http://documentserver/web-apps/apps/api/documents/api.js";
 
-$GLOBALS['DOC_SERV_PRELOADER_URL'] = "https://doc.onlyoffice.com/web-apps/apps/api/documents/cache-scripts.html";
+$GLOBALS['DOC_SERV_PRELOADER_URL'] = "http://documentserver/web-apps/apps/api/documents/cache-scripts.html";
 
 $GLOBALS['EXAMPLE_URL'] = "";
 

--- a/web/documentserver-example/ruby/config/application.rb
+++ b/web/documentserver-example/ruby/config/application.rb
@@ -39,9 +39,9 @@ module OnlineEditorsExampleRuby
     Rails.configuration.editedDocs=".docx|.xlsx|.csv|.pptx|.ppsx|.txt"
     Rails.configuration.convertDocs=".docm|.dotx|.dotm|.dot|.doc|.odt|.fodt|.xlsm|.xltx|.xltm|.xlt|.xls|.ods|.fods|.pptm|.ppt|.ppsm|.pps|.potx|.potm|.pot|.odp|.fodp|.rtf|.mht|.html|.htm|.epub"
 
-    Rails.configuration.urlConverter="https://doc.onlyoffice.com/ConvertService.ashx"
-    Rails.configuration.urlApi="https://doc.onlyoffice.com/web-apps/apps/api/documents/api.js"
-    Rails.configuration.urlPreloader="https://doc.onlyoffice.com/web-apps/apps/api/documents/cache-scripts.html"
+    Rails.configuration.urlConverter="http://documentserver/ConvertService.ashx"
+    Rails.configuration.urlApi="http://documentserver/web-apps/apps/api/documents/api.js"
+    Rails.configuration.urlPreloader="http://documentserver/web-apps/apps/api/documents/cache-scripts.html"
 
   end
 end


### PR DESCRIPTION
It has JWT enabled and will not work without secret keys.
Users should setup their own http://documentserver