### PR TITLE
nodejs: remove shebang line

### DIFF
--- a/web/documentserver-example/nodejs/bin/www
+++ b/web/documentserver-example/nodejs/bin/www
@@ -1,5 +1,4 @@
-﻿#!/usr/bin/env node
-var debug = require("debug")("OnlineEditorsExampleNodeJS");
+﻿var debug = require("debug")("OnlineEditorsExampleNodeJS");
 var app = require("../app");
 var config = require('config');
 


### PR DESCRIPTION
Do not use shebang line.
Doesn't work with it on Windows OS or Linux OS when you start it according to the [instructions](https://api.onlyoffice.com/editors/example/nodejs)