### PR TITLE
Feature/remove resource

### DIFF
--- a/web/documentserver-example/java/nb-configuration.xml
+++ b/web/documentserver-example/java/nb-configuration.xml
@@ -54,7 +54,6 @@ Any value defined here will override the pom.xml file value but is only applicab
         <word>ppsx</word>
         <word>ppt</word>
         <word>pptx</word>
-        <word>ResourceService</word>
         <word>rtf</word>
         <word>SIA</word>
         <word>teamlab</word>

--- a/web/documentserver-example/java/src/main/java/helpers/FileUtility.java
+++ b/web/documentserver-example/java/src/main/java/helpers/FileUtility.java
@@ -74,15 +74,8 @@ public class FileUtility
     {
         if (url == null) return "";
 
-        //for external file url
-        String tempstorage = ConfigManager.GetProperty("files.docservice.url.site") + ConfigManager.GetProperty("files.docservice.url.tempstorage");
-        if (!tempstorage.isEmpty() && url.startsWith(tempstorage))
-        {
-            Map<String, String> params = GetUrlParams(url);
-            return params == null ? null : params.get("filename");
-        }
-
         String fileName = url.substring(url.lastIndexOf('/') + 1, url.length());
+        fileName = fileName.split("\\?")[0];
         return fileName;
     }
 

--- a/web/documentserver-example/java/src/main/resources/settings.properties
+++ b/web/documentserver-example/java/src/main/resources/settings.properties
@@ -8,7 +8,6 @@ files.docservice.timeout=120000
 
 files.docservice.url.site=https://documentserver/
 files.docservice.url.converter=ConvertService.ashx
-files.docservice.url.tempstorage=ResourceService.ashx
 files.docservice.url.api=web-apps/apps/api/documents/api.js
 files.docservice.url.preloader=web-apps/apps/api/documents/cache-scripts.html
 files.docservice.url.example=

--- a/web/documentserver-example/nodejs/config/default.json
+++ b/web/documentserver-example/nodejs/config/default.json
@@ -15,7 +15,6 @@
     "siteUrl": "https://documentserver/",
     "commandUrl": "coauthoring/CommandService.ashx",
     "converterUrl": "ConvertService.ashx",
-    "tempStorageUrl": "ResourceService.ashx",
     "apiUrl": "web-apps/apps/api/documents/api.js",
     "preloaderUrl": "web-apps/apps/api/documents/cache-scripts.html",
     "exampleUrl": null,

--- a/web/documentserver-example/nodejs/helpers/fileUtility.js
+++ b/web/documentserver-example/nodejs/helpers/fileUtility.js
@@ -16,24 +16,14 @@
  *
  */
 
-var configServer = require('config').get('server');
-var siteUrl = configServer.get('siteUrl');
-var tempStorageUrl = siteUrl + configServer.get('tempStorageUrl');
-
 var fileUtility = {};
 
 fileUtility.getFileName = function (url, withoutExtension) {
     if (!url) return "";
 
-    var filename;
-
-    if (tempStorageUrl && url.indexOf(tempStorageUrl) == 0) {
-        var params = getUrlParams(url);
-        filename = params == null ? null : params["filename"];
-    } else {
-        var parts = url.toLowerCase().split("/");
-        fileName = parts.pop();
-    }
+    var parts = url.toLowerCase().split("/");
+    var fileName = parts.pop();
+    fileName = fileName.split("?")[0];
 
     if (withoutExtension) {
         var ext = fileUtility.getFileExtension(fileName);


### PR DESCRIPTION
The `tempstorage` as `ResourceService.ashx` is not used anymore.
The `FileUrl` from the result of the conversion service is now different.
The name from the link as the last element after the "/" and before the "?".