### PR TITLE
Feature/bug ruby editor

### DIFF
--- a/web/documentserver-example/ruby/app/assets/stylesheets/stylesheet.scss
+++ b/web/documentserver-example/ruby/app/assets/stylesheets/stylesheet.scss
@@ -35,6 +35,7 @@ body {
     padding: 0;
     text-decoration: none;
     overflow-x: hidden;
+    width: 100%;
 }
 
 form {


### PR DESCRIPTION
display: inline-block this breaks the editor display. Other examples initially use this display: block