### PR TITLE
php: empty GET parameters warnings fixed

### DIFF
--- a/web/documentserver-example/php/doceditor.php
+++ b/web/documentserver-example/php/doceditor.php
@@ -23,13 +23,12 @@
     require_once( dirname(__FILE__) . '/jwtmanager.php' );
     require_once( dirname(__FILE__) . '/users.php' );
 
-    $filename;
 
     $user = getUser($_GET["user"]);
-    $isEnableDirectUrl = $_GET["directUrl"] != null ? filter_var($_GET["directUrl"], FILTER_VALIDATE_BOOLEAN) : false;
+    $isEnableDirectUrl = isset($_GET["directUrl"]) ? filter_var($_GET["directUrl"], FILTER_VALIDATE_BOOLEAN) : false;
 
     // get the file url and upload it
-    $externalUrl = $_GET["fileUrl"];
+    $externalUrl = isset($_GET["fileUrl"]) ? $_GET["fileUrl"] : "";
     if (!empty($externalUrl))
     {
         $filename = DoUpload($externalUrl);
@@ -39,7 +38,7 @@
     {
         $filename = basename($_GET["fileID"]);
     }
-    $createExt = $_GET["fileExt"];
+    $createExt = isset($_GET["fileExt"]) ? $_GET["fileExt"] : "";
 
     if (!empty($createExt))
     {

--- a/web/documentserver-example/php/index.php
+++ b/web/documentserver-example/php/index.php
@@ -22,8 +22,8 @@
     require_once( dirname(__FILE__) . '/functions.php' );
     require_once( dirname(__FILE__) . '/users.php' );
 
-    $user = $_GET["user"];
-    $directUrlArg = $_GET["directUrl"] != null ? "&directUrl=" . $_GET["directUrl"] : "";
+    $user = isset($_GET["user"]) ? $_GET["user"] : "";
+    $directUrlArg = isset($_GET["directUrl"]) ? "&directUrl=" . $_GET["directUrl"] : "";
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
Empty GET-parameters "user", "directUrl",  "fileUrl", "fileExt" no longer give a warning, the example can work without them.