### PR TITLE
java: upload and convert fix

### DIFF
--- a/web/documentserver-example/java/src/main/java/controllers/IndexServlet.java
+++ b/web/documentserver-example/java/src/main/java/controllers/IndexServlet.java
@@ -78,6 +78,11 @@ public class IndexServlet extends HttpServlet {
             return;
         }
 
+        // charset for response headers if upload or convert
+        if (action.matches("upload|convert")) {
+           response.setCharacterEncoding("UTF-8");
+        }
+
         DocumentManager.init(request, response);
 
         // create a variable to display information about the application and error messages

--- a/web/documentserver-example/java/src/main/java/helpers/ServiceConverter.java
+++ b/web/documentserver-example/java/src/main/java/helpers/ServiceConverter.java
@@ -213,13 +213,14 @@ public final class ServiceConverter {
 
         connection.connect();
 
+
+        try (OutputStream os = connection.getOutputStream()) {
+            os.write(bodyByte);
+        }
         int statusCode = connection.getResponseCode();
         if (statusCode != HttpServletResponse.SC_OK) {  // checking status code
             connection.disconnect();
             throw new Exception("Conversion service returned status: " + statusCode);
-        }
-        try (OutputStream os = connection.getOutputStream()) {
-            os.write(bodyByte);
         }
 
         InputStream stream = connection.getInputStream();


### PR DESCRIPTION
1.  `IndexServlet.java`. The `upload` method returned an ISO-8859-1 encoded response. The `convert` method received incorrect filenames if they contained non-Latin characters. Added UTF-8 encoding to response header for `upload` or `convert` actions.
2. `ServiceConverter.java`. Trying to get the response code before setting the response body resulted in an exception (insufficient data written).