### PR TITLE
nodejs: hasOwnProperty() used instead of hasOwn() for NodeJS v.14

### DIFF
--- a/web/documentserver-example/nodejs/.eslintrc.js
+++ b/web/documentserver-example/nodejs/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
     'no-continue': 'off',
     'no-extend-native': ['error', { exceptions: ['String'] }],
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
+    'no-prototype-builtins': 'off',
   },
 };

--- a/web/documentserver-example/nodejs/app.js
+++ b/web/documentserver-example/nodejs/app.js
@@ -807,7 +807,7 @@ app.post('/track', async (req, res) => { // define a handler for tracking file c
   // check jwt token
   if (cfgSignatureEnable && cfgSignatureUseForRequest) {
     let body = null;
-    if (Object.hasOwn(req.body, 'token')) { // if request body has its own token
+    if (req.body.hasOwnProperty('token')) { // if request body has its own token
       body = documentService.readToken(req.body.token); // read and verify it
     } else {
       const checkJwtHeaderRes = documentService.checkJwtHeader(req); // otherwise, check jwt token headers
@@ -835,7 +835,7 @@ app.post('/track', async (req, res) => { // define a handler for tracking file c
     return;
   }
 
-  if (Object.hasOwn(req.body, 'status')) { // if the request body has status parameter
+  if (req.body.hasOwnProperty('status')) { // if the request body has status parameter
     await processTrack(res, req.body, fName, uAddress); // track file changes
   } else {
     await readbody(req, res, fName, uAddress); // otherwise, read request body first


### PR DESCRIPTION
`hasOwnProperty()` used instead of `hasOwn()` for **NodeJS v.14**