### PR TITLE
nodejs: get history data by request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- nodejs: getting history by a separate request
 - nodejs: setUsers for region protection
 - si skin languages
 - fix "no" skin languages

--- a/web/documentserver-example/nodejs/app.js
+++ b/web/documentserver-example/nodejs/app.js
@@ -848,8 +848,6 @@ app.get('/editor', (req, res) => { // define a handler for editing document
 
     const fileName = fileUtility.getFileName(req.query.fileName);
     let { fileExt } = req.query;
-    const history = [];
-    const historyData = [];
     const lang = req.DocManager.getLang();
     const user = users.getUser(req.query.userid);
     const userDirectUrl = req.query.directUrl === 'true';
@@ -927,76 +925,6 @@ app.get('/editor', (req, res) => { // define a handler for editing document
     }
     const submitForm = mode === 'fillForms' && userid === 'uid-1' && !1;
 
-    let countVersion = 1;
-
-    const historyPath = req.DocManager.historyPath(fileName, userAddress);
-    let changes = null;
-    let keyVersion = key;
-
-    if (historyPath !== '') {
-      countVersion = req.DocManager.countVersion(historyPath) + 1; // get the number of file versions
-      for (let i = 1; i <= countVersion; i++) { // get keys to all the file versions
-        if (i < countVersion) {
-          const keyPath = req.DocManager.keyPath(fileName, userAddress, i);
-          if (!fileSystem.existsSync(keyPath)) continue;
-          keyVersion = `${fileSystem.readFileSync(keyPath)}`;
-        } else {
-          keyVersion = key;
-        }
-        // write all the file history information
-        history.push(req.DocManager.getHistory(fileName, changes, keyVersion, i));
-
-        const userUrl = i === countVersion ? directUrl : (`${req.DocManager.getServerUrl(false)}/history?fileName=`
-        + `${encodeURIComponent(fileName)}&file=prev${fileExt}&ver=${i}`);
-        const historyD = {
-          fileType: fileExt.slice(1),
-          version: i,
-          key: keyVersion,
-          url: i === countVersion ? url : (`${req.DocManager.getServerUrl(true)}/history?fileName=`
-          + `${encodeURIComponent(fileName)}&file=prev${fileExt}&ver=${i}&useraddress=${userAddress}`),
-          directUrl: !userDirectUrl ? null : userUrl,
-        };
-
-        // check if the path to the file with document versions differences exists
-        if (i > 1 && req.DocManager.existsSync(req.DocManager.diffPath(fileName, userAddress, i - 1))) {
-          historyD.previous = { // write information about previous file version
-            fileType: historyData[i - 2].fileType,
-            key: historyData[i - 2].key,
-            url: historyData[i - 2].url,
-            directUrl: !userDirectUrl ? null : historyData[i - 2].directUrl,
-          };
-          const changesUrl = `${req.DocManager.getServerUrl(true)}/history?fileName=`
-          + `${encodeURIComponent(fileName)}&file=diff.zip&ver=${i - 1}&useraddress=${userAddress}`;
-          historyD.changesUrl = changesUrl; // get the path to the diff.zip file and write it to the history object
-        }
-
-        historyData.push(historyD);
-
-        if (i < countVersion) {
-          // get the path to the file with document changes
-          const changesFile = req.DocManager.changesPath(fileName, userAddress, i);
-          changes = req.DocManager.getChanges(changesFile); // get changes made in the file
-        }
-      }
-    } else { // if history path is empty
-      // write the history information about the last file version
-      history.push(req.DocManager.getHistory(fileName, changes, keyVersion, countVersion));
-      historyData.push({
-        fileType: fileExt.slice(1),
-        version: countVersion,
-        key,
-        url,
-        directUrl: !userDirectUrl ? null : directUrl,
-      });
-    }
-
-    if (cfgSignatureEnable) {
-      for (let i = 0; i < historyData.length; i++) {
-        // sign token with given data using signature secret
-        historyData[i].token = jwt.sign(historyData[i], cfgSignatureSecret, { expiresIn: cfgSignatureSecretExpiresIn });
-      }
-    }
-
     // file config data
     const argss = {
       apiUrl: siteUrl + configServer.get('apiUrl'),
@@ -1006,7 +934,6 @@ app.get('/editor', (req, res) => { // define a handler for editing document
         uri: url,
         directUrl: !userDirectUrl ? null : directUrl,
         uriUser: directUrl,
-        version: countVersion,
         created: new Date().toDateString(),
         favorite: user.favorite != null ? user.favorite : 'null',
       },
@@ -1049,8 +976,6 @@ app.get('/editor', (req, res) => { // define a handler for editing document
         instanceId: userid !== 'uid-0' ? req.DocManager.getInstanceId() : null,
         protect: !user.deniedPermissions.includes('protect'),
       },
-      history,
-      historyData,
       dataInsertImage: {
         fileType: 'png',
         url: `${req.DocManager.getServerUrl(true)}/images/logo.png`,
@@ -1127,6 +1052,27 @@ app.post('/rename', (req, res) => { // define a handler for renaming file
   };
 
   documentService.commandRequest('meta', dockey, result, meta);
+});
+
+app.post('/historyObj', (req, res) => {
+  req.DocManager = new DocManager(req, res);
+  const { fileName } = req.body;
+  const { directUrl } = req.body || null;
+  const historyObj = req.DocManager.getHistoryObject(fileName, null, directUrl);
+
+  if (cfgSignatureEnable) {
+    for (let i = 0; i < historyObj.historyData.length; i++) {
+      // sign token with given data using signature secret
+      historyObj.historyData[i].token = jwt.sign(
+        historyObj.historyData[i],
+        cfgSignatureSecret,
+        { expiresIn: cfgSignatureSecretExpiresIn },
+      );
+    }
+  }
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.write(JSON.stringify(historyObj));
+  res.end();
 });
 
 wopiApp.registerRoutes(app);

--- a/web/documentserver-example/nodejs/views/editor.ejs
+++ b/web/documentserver-example/nodejs/views/editor.ejs
@@ -76,8 +76,8 @@
             const fileName = "<%- file.name %>" || null;
             const directUrl = "<%- file.directUrl %>" || null;
             const data = {
-              fileName,
-              directUrl
+              fileName: fileName,
+              directUrl: directUrl
             };
             let xhr = new XMLHttpRequest();
             xhr.open("POST", "historyObj");

--- a/web/documentserver-example/nodejs/views/editor.ejs
+++ b/web/documentserver-example/nodejs/views/editor.ejs
@@ -72,20 +72,41 @@
         };
 
         var onRequestHistory = function (event) {  // the user is trying to show the document version history
-            var historyObj = <%- JSON.stringify(history) %> || null;
-
+            const fileName = "<%- file.name %>" || null;
+            const directUrl = "<%- file.directUrl %>" || null;
+            const data = {
+              fileName,
+              directUrl
+            };
+            let xhr = new XMLHttpRequest();
+            xhr.open("POST", "historyObj");
+            xhr.setRequestHeader("Content-Type", "application/json");
+            xhr.send(JSON.stringify(data));
+            xhr.onload = function () {
+              const response = JSON.parse(xhr.responseText);
             docEditor.refreshHistory(  // show the document version history
-                {
-                    currentVersion: "<%- file.version %>",
-                    history: historyObj
-                });
+              {
+                currentVersion: response.countVersion,
+                history: response.history
+              });
+            }
         };
 
-        var onRequestHistoryData = function (data) {  // the user is trying to click the specific document version in the document version history
-            var version = data.data;
-            var historyData = <%- JSON.stringify(historyData) %> || null;
-
-            docEditor.setHistoryData(historyData[version-1]);  // send the link to the document for viewing the version history
+        var onRequestHistoryData = function (event) {  // the user is trying to click the specific document version in the document version history
+          const fileName = "<%- file.name %>" || null;
+          const directUrl = "<%- file.directUrl %>" || null;
+          const version = event.data;
+          const data = {
+            fileName,
+            directUrl
+          };
+          let xhr = new XMLHttpRequest();
+          xhr.open("POST", "historyObj");
+          xhr.setRequestHeader("Content-Type", "application/json");
+          xhr.send(JSON.stringify(data));
+          xhr.onload = function () {
+            docEditor.setHistoryData(JSON.parse(xhr.responseText).historyData[version-1]);  // send the link to the document for viewing the version history
+          }
         };
 
         var onRequestHistoryClose = function (event){  // the user is trying to go back to the document from viewing the document version history

--- a/web/documentserver-example/nodejs/views/editor.ejs
+++ b/web/documentserver-example/nodejs/views/editor.ejs
@@ -39,6 +39,7 @@
 
         var docEditor;
         var config;
+        let historyObject;
 
         var innerAlert = function (message, inEditor) {
             if (console && console.log)
@@ -83,30 +84,18 @@
             xhr.setRequestHeader("Content-Type", "application/json");
             xhr.send(JSON.stringify(data));
             xhr.onload = function () {
-              const response = JSON.parse(xhr.responseText);
-            docEditor.refreshHistory(  // show the document version history
-              {
-                currentVersion: response.countVersion,
-                history: response.history
-              });
+              historyObject = JSON.parse(xhr.responseText);
+              docEditor.refreshHistory(  // show the document version history
+                {
+                  currentVersion: historyObject.countVersion,
+                  history: historyObject.history
+                });
             }
         };
 
         var onRequestHistoryData = function (event) {  // the user is trying to click the specific document version in the document version history
-          const fileName = "<%- file.name %>" || null;
-          const directUrl = "<%- file.directUrl %>" || null;
           const version = event.data;
-          const data = {
-            fileName,
-            directUrl
-          };
-          let xhr = new XMLHttpRequest();
-          xhr.open("POST", "historyObj");
-          xhr.setRequestHeader("Content-Type", "application/json");
-          xhr.send(JSON.stringify(data));
-          xhr.onload = function () {
-            docEditor.setHistoryData(JSON.parse(xhr.responseText).historyData[version-1]);  // send the link to the document for viewing the version history
-          }
+          docEditor.setHistoryData(historyObject.historyData[version-1]);  // send the link to the document for viewing the version history
         };
 
         var onRequestHistoryClose = function (event){  // the user is trying to go back to the document from viewing the document version history


### PR DESCRIPTION
Logic of collecting history data moved to special method of `DocManager`. Method used in `onRequestHistory` and `onRequestHistoryData` events.