### PR TITLE
ruby: add missed configuration manager tests

### DIFF
--- a/web/documentserver-example/ruby/Gemfile
+++ b/web/documentserver-example/ruby/Gemfile
@@ -13,6 +13,7 @@ gem "rubocop", "~> 1.52", :group => :development
 gem "sass-rails", "~> 6.0"
 gem "sdoc", "~> 2.6", :group => :doc
 gem "sorbet-runtime", "~> 0.5.10871"
+gem "test-unit", "~> 3.6", :groups => [:development, :test]
 gem "turbolinks", "~> 5.2"
 gem "tzinfo-data", "~> 1.2023"
 gem "uglifier", "~> 4.2"

--- a/web/documentserver-example/ruby/Gemfile.lock
+++ b/web/documentserver-example/ruby/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    power_assert (2.0.3)
     psych (5.1.0)
       stringio
     racc (1.7.0)
@@ -241,6 +242,8 @@ GEM
       spoom (~> 1.2.0, >= 1.2.0)
       thor (>= 1.2.0)
       yard-sorbet
+    test-unit (3.6.1)
+      power_assert
     thor (1.2.2)
     tilt (2.2.0)
     timeout (0.3.2)
@@ -295,6 +298,7 @@ DEPENDENCIES
   sorbet (~> 0.5.10871)
   sorbet-runtime (~> 0.5.10871)
   tapioca (~> 0.11.6)
+  test-unit (~> 3.6)
   turbolinks (~> 5.2)
   tzinfo-data (~> 1.2023)
   uglifier (~> 4.2)

--- a/web/documentserver-example/ruby/Makefile
+++ b/web/documentserver-example/ruby/Makefile
@@ -29,3 +29,7 @@ prod: #         Install production dependencies.
 .PHONY: prod-server
 prod-server: #  Start the poruction server on 0.0.0.0 at $PORT (default: 3000).
 	@bundle exec rails server --environment production
+
+.PHONY: test
+test: #         Recursively run the tests.
+	@bundle exec rake test

--- a/web/documentserver-example/ruby/Rakefile
+++ b/web/documentserver-example/ruby/Rakefile
@@ -1,3 +1,8 @@
+require 'rake/testtask'
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['app/**/*_tests.rb']
+end

--- a/web/documentserver-example/ruby/app/configuration/configuration.rb
+++ b/web/documentserver-example/ruby/app/configuration/configuration.rb
@@ -105,7 +105,8 @@ class ConfigurationManager
     storage_directory = Pathname(storage_path)
     return storage_directory if storage_directory.absolute?
     current_directory = Pathname(File.expand_path(__dir__))
-    current_directory.join('..', storage_directory)
+    directory = current_directory.join('..', '..', storage_directory)
+    directory.cleanpath
   end
 
   sig { returns(Numeric) }

--- a/web/documentserver-example/ruby/app/configuration/configuration.rb
+++ b/web/documentserver-example/ruby/app/configuration/configuration.rb
@@ -17,6 +17,9 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'active_model'
+require 'pathname'
+require 'sorbet-runtime'
 require 'uri'
 
 class ConfigurationManager

--- a/web/documentserver-example/ruby/app/configuration/configuration_tests.rb
+++ b/web/documentserver-example/ruby/app/configuration/configuration_tests.rb
@@ -1,0 +1,284 @@
+#
+# (c) Copyright Ascensio System SIA 2023
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# frozen_string_literal: true
+# typed: true
+
+require 'test/unit'
+require_relative 'configuration'
+
+module Enviroment
+  def initialize(name)
+    @env = ENV.to_hash
+    super(name)
+  end
+
+  def setup
+    ENV.replace @env
+  end
+end
+
+class ConfigurationManagerTests < Test::Unit::TestCase
+  def test_corresponds_the_latest_version
+    config_manager = ConfigurationManager.new
+    assert_equal(config_manager.version, '1.6.0')
+  end
+end
+
+class ConfigurationManagerExampleURITests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    uri = config_manager.example_uri
+    assert_nil(uri)
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['EXAMPLE_URL'] = 'http://localhost'
+    config_manager = ConfigurationManager.new
+    uri = config_manager.example_uri
+    assert_equal(uri.to_s, 'http://localhost')
+  end
+end
+
+class ConfigurationManagerDocumentServerURITests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_uri
+    assert_equal(uri.to_s, 'http://document-server')
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['DOCUMENT_SERVER_URL'] = 'http://localhost'
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_uri
+    assert_equal(uri.to_s, 'http://localhost')
+  end
+end
+
+class ConfigurationManagerDocumentServerAPIURITests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_api_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/web-apps/apps/api/documents/api.js'
+    )
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['DOCUMENT_SERVER_API_PATH'] = '/api'
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_api_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/api'
+    )
+  end
+end
+
+class ConfigurationManagerDocumentServerPreloaderURITests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_preloader_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/web-apps/apps/api/documents/cache-scripts.html'
+    )
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['DOCUMENT_SERVER_PRELOADER_PATH'] = '/preloader'
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_preloader_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/preloader'
+    )
+  end
+end
+
+class ConfigurationManagerDocumentServerCommandURITests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_command_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/coauthoring/CommandService.ashx'
+    )
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['DOCUMENT_SERVER_COMMAND_PATH'] = '/command'
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_command_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/command'
+    )
+  end
+end
+
+class ConfigurationManagerDocumentServerConverterURITests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_converter_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/ConvertService.ashx'
+    )
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['DOCUMENT_SERVER_CONVERTER_PATH'] = '/converter'
+    config_manager = ConfigurationManager.new
+    uri = config_manager.document_server_converter_uri
+    assert_equal(
+      uri.to_s,
+      'http://document-server/converter'
+    )
+  end
+end
+
+class ConfigurationManagerJWTSecretTests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    secret = config_manager.jwt_secret
+    assert_equal(secret, '')
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['JWT_SECRET'] = 'your-256-bit-secret'
+    config_manager = ConfigurationManager.new
+    secret = config_manager.jwt_secret
+    assert_equal(secret, 'your-256-bit-secret')
+  end
+end
+
+class ConfigurationManagerJWTHeaderTests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    header = config_manager.jwt_header
+    assert_equal(header, 'Authorization')
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['JWT_HEADER'] = 'Proxy-Authorization'
+    config_manager = ConfigurationManager.new
+    header = config_manager.jwt_header
+    assert_equal(header, 'Proxy-Authorization')
+  end
+end
+
+class ConfigurationManagerJWTUseForRequest < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    use = config_manager.jwt_use_for_request
+    assert_true(use)
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['JWT_USE_FOR_REQUEST'] = 'false'
+    config_manager = ConfigurationManager.new
+    use = config_manager.jwt_use_for_request
+    assert_false(use)
+  end
+end
+
+class ConfigurationManagerSSLTests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    enabled = config_manager.ssl_verify_peer_mode_enabled
+    assert_false(enabled)
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['SSL_VERIFY_PEER_MODE_ENABLED'] = 'true'
+    config_manager = ConfigurationManager.new
+    enabled = config_manager.ssl_verify_peer_mode_enabled
+    assert_true(enabled)
+  end
+end
+
+class ConfigurationManagerStoragePathTests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    path = config_manager.storage_path
+    assert_true(path.absolute?)
+    assert_equal(path.basename.to_s, 'storage')
+  end
+
+  def test_assigns_a_relative_path_from_the_environment
+    ENV['STORAGE_PATH'] = 'directory'
+    config_manager = ConfigurationManager.new
+    path = config_manager.storage_path
+    assert_true(path.absolute?)
+    assert_equal(path.basename.to_s, 'directory')
+  end
+
+  def test_assigns_an_absolute_path_from_the_environment
+    ENV['STORAGE_PATH'] = '/directory'
+    config_manager = ConfigurationManager.new
+    path = config_manager.storage_path
+    assert_equal(path.to_s, '/directory')
+  end
+end
+
+class ConfigurationManagerMaximumFileSizeTests < Test::Unit::TestCase
+  include Enviroment
+
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    size = config_manager.maximum_file_size
+    assert_equal(size, 5_242_880)
+  end
+
+  def test_assigns_a_value_from_the_environment
+    ENV['MAXIMUM_FILE_SIZE'] = '10'
+    config_manager = ConfigurationManager.new
+    size = config_manager.maximum_file_size
+    assert_equal(size, 10)
+  end
+end
+
+class ConfigurationManagerConversionTimeoutTests < Test::Unit::TestCase
+  def test_assigns_a_default_value
+    config_manager = ConfigurationManager.new
+    timeout = config_manager.convertation_timeout
+    assert_equal(timeout, 120)
+  end
+end

--- a/web/documentserver-example/ruby/app/controllers/home_controller.rb
+++ b/web/documentserver-example/ruby/app/controllers/home_controller.rb
@@ -16,7 +16,7 @@
 
 require 'net/http'
 require 'mimemagic'
-require_relative '../configuration'
+require_relative '../configuration/configuration'
 
 class HomeController < ApplicationController
   @config_manager = ConfigurationManager.new

--- a/web/documentserver-example/ruby/app/models/document_helper.rb
+++ b/web/documentserver-example/ruby/app/models/document_helper.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require_relative '../configuration'
+require_relative '../configuration/configuration'
 
 class DocumentHelper
   @config_manager = ConfigurationManager.new

--- a/web/documentserver-example/ruby/app/models/file_model.rb
+++ b/web/documentserver-example/ruby/app/models/file_model.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require_relative '../configuration'
+require_relative '../configuration/configuration'
 
 class FileModel
 

--- a/web/documentserver-example/ruby/app/models/jwt_helper.rb
+++ b/web/documentserver-example/ruby/app/models/jwt_helper.rb
@@ -15,7 +15,7 @@
 #
 
 require 'jwt'
-require_relative '../configuration'
+require_relative '../configuration/configuration'
 
 class JwtHelper
 

--- a/web/documentserver-example/ruby/app/models/service_converter.rb
+++ b/web/documentserver-example/ruby/app/models/service_converter.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require_relative '../configuration'
+require_relative '../configuration/configuration'
 
 class ServiceConverter
   @config_manager = ConfigurationManager.new

--- a/web/documentserver-example/ruby/app/models/track_helper.rb
+++ b/web/documentserver-example/ruby/app/models/track_helper.rb
@@ -15,7 +15,7 @@
 #
 
 require 'net/http'
-require_relative '../configuration'
+require_relative '../configuration/configuration'
 
 class TrackHelper
   @config_manager = ConfigurationManager.new


### PR DESCRIPTION
Please note that in this PR, I have added a new dependency called [`test-unit`](https://github.com/test-unit/test-unit). However, we don't need to add a license for this dependency to the project. `test-unit` is a built-in language library, and I have marked it as a dependency to ensure that all tests can be run using the `Makefile`/`Rakefile`. See https://github.com/rspec/rspec-rails/issues/1273 for details.
