### PR TITLE
php: add missed path tests and rewrite path methods a bit

### DIFF
--- a/web/documentserver-example/php/Makefile
+++ b/web/documentserver-example/php/Makefile
@@ -19,4 +19,4 @@ lint: #  Lint the source code for the style.
 
 .PHONY: test
 test: #  Run tests recursively.
-	@./vendor/bin/phpunit ./**/*Tests.php
+	@./vendor/bin/phpunit --test-suffix "Tests.php" common

--- a/web/documentserver-example/php/ajax.php
+++ b/web/documentserver-example/php/ajax.php
@@ -627,7 +627,7 @@ function restore()
         }
         $bumped_version_directory = new Path($bumped_version_string_directory);
 
-        $bumped_key_file = $bumped_version_directory->join('key.txt');
+        $bumped_key_file = $bumped_version_directory->join_path('key.txt');
         $bumped_key_string_file = $bumped_key_file->string();
         $bumped_key = getDocEditorKey($source_basename);
         file_put_contents($bumped_key_string_file, $bumped_key, LOCK_EX);
@@ -635,7 +635,7 @@ function restore()
         $users = new ExampleUsers();
         $user = $users->getUser($user_id);
 
-        $bumped_changes_file = $bumped_version_directory->join('changes.json');
+        $bumped_changes_file = $bumped_version_directory->join_path('changes.json');
         $bumped_changes_string_file = $bumped_changes_file->string();
         $bumped_changes = [
             'serverVersion' => null,
@@ -655,13 +655,13 @@ function restore()
         $source_extension = pathinfo($source_basename, PATHINFO_EXTENSION);
         $previous_basename = "prev.{$source_extension}";
 
-        $bumped_file = $bumped_version_directory->join($previous_basename);
+        $bumped_file = $bumped_version_directory->join_path($previous_basename);
         $bumped_string_file = $bumped_file->string();
         copy($source_file, $bumped_string_file);
 
         $recovery_version_string_directory = getVersionDir($history_directory, $version);
         $recovery_version_directory = new Path($recovery_version_string_directory);
-        $recovery_file = $recovery_version_directory->join($previous_basename);
+        $recovery_file = $recovery_version_directory->join_path($previous_basename);
         $recovery_string_file = $recovery_file->string();
         copy($recovery_string_file, $source_file);
 

--- a/web/documentserver-example/php/common/Path.php
+++ b/web/documentserver-example/php/common/Path.php
@@ -19,59 +19,38 @@ namespace OnlineEditorsExamplePhp\Common;
 
 final class Path {
     private string $separator = DIRECTORY_SEPARATOR;
-
-    public ?string $dirname;
-    public ?string $basename;
-    public ?string $extension;
-    public ?string $filename;
+    private string $string;
 
     public function __construct(string $path) {
-        $parsed_path = pathinfo($path);
-        $this->dirname = self::dirname($parsed_path);
-        $this->basename = self::basename($parsed_path);
-        $this->extension = self::extension($parsed_path);
-        $this->filename = self::filename($parsed_path);
-    }
-
-    private static function dirname(array $path): ?string {
-        return isset($path['dirname'])
-            ? $path['dirname']
-            : null;
-    }
-
-    private static function basename(array $path): ?string {
-        return isset($path['basename'])
-            ? $path['basename']
-            : null;
-    }
-
-    private static function extension(array $path): ?string {
-        return isset($path['extension'])
-            ? $path['extension']
-            : null;
-    }
-
-    private static function filename(array $path): ?string {
-        return isset($path['filename'])
-            ? $path['filename']
-            : null;
+        $this->string = $path;
     }
 
     public function string(): string {
-        $parts = array();
-        if (!$this->dirname && !$this->basename) {
-            return '.';
-        }
-        if ($this->dirname === $this->separator && $this->basename) {
-            return "{$this->dirname}{$this->basename}";
-        }
-        if ($this->dirname !== '.') {
-            $parts[] = $this->dirname;
-        }
-        if ($this->basename) {
-            $parts[] = $this->basename;
-        }
-        return implode($this->separator, $parts);
+        return $this->string;
+    }
+
+    public function dirname(): ?string {
+        $string = $this->string();
+        $parsed = pathinfo($string, PATHINFO_DIRNAME);
+        return $parsed ?: null;
+    }
+
+    public function basename(): ?string {
+        $string = $this->string();
+        $parsed = pathinfo($string, PATHINFO_BASENAME);
+        return $parsed ?: null;
+    }
+
+    public function extension(): ?string {
+        $string = $this->string();
+        $parsed = pathinfo($string, PATHINFO_EXTENSION);
+        return $parsed ?: null;
+    }
+
+    public function filename(): ?string {
+        $string = $this->string();
+        $parsed = pathinfo($string, PATHINFO_FILENAME);
+        return $parsed ?: null;
     }
 
     public function join(string ...$paths): self {

--- a/web/documentserver-example/php/common/Path.php
+++ b/web/documentserver-example/php/common/Path.php
@@ -18,18 +18,15 @@
 namespace OnlineEditorsExamplePhp\Common;
 
 final class Path {
-    public string $separator;
+    private string $separator = DIRECTORY_SEPARATOR;
+
     public ?string $dirname;
     public ?string $basename;
     public ?string $extension;
     public ?string $filename;
 
-    public function __construct(
-        string $path,
-        string $separator = DIRECTORY_SEPARATOR
-    ) {
+    public function __construct(string $path) {
         $parsed_path = pathinfo($path);
-        $this->separator = $separator;
         $this->dirname = self::dirname($parsed_path);
         $this->basename = self::basename($parsed_path);
         $this->extension = self::extension($parsed_path);
@@ -87,7 +84,7 @@ final class Path {
             return $this->join(...$next_paths);
         }
 
-        $sub = new Path($paths[0], $this->separator);
+        $sub = new Path($paths[0]);
         $sub_string = $sub->string();
 
         $string = $this->string();
@@ -96,7 +93,7 @@ final class Path {
             : $this->separator;
 
         $joined_string = "{$string}{$separator}{$sub_string}";
-        $joined = new Path($joined_string, $this->separator);
+        $joined = new Path($joined_string);
 
         return $joined->join(...$next_paths);
     }

--- a/web/documentserver-example/php/common/PathJoinPOSIXTests.php
+++ b/web/documentserver-example/php/common/PathJoinPOSIXTests.php
@@ -1,0 +1,84 @@
+<?php
+//
+// (c) Copyright Ascensio System SIA 2023
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use PHPUnit\Framework\TestCase;
+use OnlineEditorsExamplePhp\Common\Path;
+
+final class PathJoinPOSIXTests extends TestCase {
+    public function test_joins_a_relative_to_an_empty_one() {
+        $path = new Path('');
+        $joined = $path->join_path('srv');
+        $this->assertEquals($joined->dirname(), '/');
+        $this->assertEquals($joined->basename(), 'srv');
+        $this->assertEquals($joined->extension(), null);
+        $this->assertEquals($joined->filename(), 'srv');
+    }
+
+    public function test_joins_a_relative_to_a_relative_one() {
+        $path = new Path('.');
+        $joined = $path->join_path('srv');
+        $this->assertEquals($joined->dirname(), '.');
+        $this->assertEquals($joined->basename(), 'srv');
+        $this->assertEquals($joined->extension(), null);
+        $this->assertEquals($joined->filename(), 'srv');
+    }
+
+    public function test_joins_a_relative_to_an_absolute_one() {
+        $path = new Path('/');
+        $joined = $path->join_path('srv');
+        $this->assertEquals($joined->dirname(), '/');
+        $this->assertEquals($joined->basename(), 'srv');
+        $this->assertEquals($joined->extension(), null);
+        $this->assertEquals($joined->filename(), 'srv');
+    }
+
+    public function test_joins_an_absolute_to_an_empty_one() {
+        $path = new Path('');
+        $joined = $path->join_path('/srv');
+        $this->assertEquals($joined->dirname(), '/');
+        $this->assertEquals($joined->basename(), 'srv');
+        $this->assertEquals($joined->extension(), null);
+        $this->assertEquals($joined->filename(), 'srv');
+    }
+
+    public function test_joins_an_absolute_to_a_relative_one() {
+        $path = new Path('.');
+        $joined = $path->join_path('/srv');
+        $this->assertEquals($joined->dirname(), '.');
+        $this->assertEquals($joined->basename(), 'srv');
+        $this->assertEquals($joined->extension(), null);
+        $this->assertEquals($joined->filename(), 'srv');
+    }
+
+    public function test_joins_an_absolute_to_an_absolute_one() {
+        $path = new Path('/');
+        $joined = $path->join_path('/srv');
+        $this->assertEquals($joined->dirname(), '/');
+        $this->assertEquals($joined->basename(), 'srv');
+        $this->assertEquals($joined->extension(), null);
+        $this->assertEquals($joined->filename(), 'srv');
+    }
+
+    public function test_joins_an_unnormalized() {
+        $path = new Path('');
+        $joined = $path->join_path('../srv');
+        $this->assertEquals($joined->dirname(), '/..');
+        $this->assertEquals($joined->basename(), 'srv');
+        $this->assertEquals($joined->extension(), null);
+        $this->assertEquals($joined->filename(), 'srv');
+    }
+}

--- a/web/documentserver-example/php/common/PathNormalizePOSIXTests.php
+++ b/web/documentserver-example/php/common/PathNormalizePOSIXTests.php
@@ -1,0 +1,30 @@
+<?php
+//
+// (c) Copyright Ascensio System SIA 2023
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use PHPUnit\Framework\TestCase;
+use OnlineEditorsExamplePhp\Common\Path;
+
+final class PathNormalizePOSIXTests extends TestCase {
+    public function test_normalizes() {
+        $path = new Path('./srv///sub/.././sub/file.docx');
+        $normalized = $path->normalize();
+        $this->assertEquals($normalized->dirname(), 'srv/sub');
+        $this->assertEquals($normalized->basename(), 'file.docx');
+        $this->assertEquals($normalized->extension(), 'docx');
+        $this->assertEquals($normalized->filename(), 'file');
+    }
+}

--- a/web/documentserver-example/php/common/PathStringPOSIXTests.php
+++ b/web/documentserver-example/php/common/PathStringPOSIXTests.php
@@ -1,0 +1,150 @@
+<?php
+//
+// (c) Copyright Ascensio System SIA 2023
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use PHPUnit\Framework\TestCase;
+use OnlineEditorsExamplePhp\Common\Path;
+
+final class PathStringPOSIXTests extends TestCase {
+    public function test_generates_with_an_empty() {
+        $path = new Path('');
+        $string = $path->string();
+        $this->assertEquals($string, '');
+    }
+
+    public function test_generates_with_an_empty_relative() {
+        $path = new Path('.');
+        $string = $path->string();
+        $this->assertEquals($string, '.');
+    }
+
+    public function test_generates_with_an_empty_absolute() {
+        $path = new Path('/');
+        $string = $path->string();
+        $this->assertEquals($string, '/');
+    }
+
+    public function test_generates_with_a_relative() {
+        $path = new Path('srv');
+        $string = $path->string();
+        $this->assertEquals($string, 'srv');
+    }
+
+    public function test_generates_with_a_relative_containing_a_directory() {
+        $path = new Path('srv/sub');
+        $string = $path->string();
+        $this->assertEquals($string, 'srv/sub');
+    }
+
+    public function test_generates_with_a_relative_containing_a_file() {
+        $path = new Path('srv/file.json');
+        $string = $path->string();
+        $this->assertEquals($string, 'srv/file.json');
+    }
+
+    public function test_generates_with_a_relative_containing_a_directory_with_a_file() {
+        $path = new Path('srv/sub/file.json');
+        $string = $path->string();
+        $this->assertEquals($string, 'srv/sub/file.json');
+    }
+
+    public function test_generates_with_an_unnormalized_relative() {
+        $path = new Path('srv////sub///file.json');
+        $string = $path->string();
+        $this->assertEquals($string, 'srv////sub///file.json');
+    }
+
+    public function test_generates_with_an_normalized_relative() {
+        $path = new Path('srv////sub///file.json');
+        $normalized = $path->normalize();
+        $string = $normalized->string();
+        $this->assertEquals($string, 'srv/sub/file.json');
+    }
+
+    public function test_generates_with_an_explicit_relative() {
+        $path = new Path('./srv');
+        $string = $path->string();
+        $this->assertEquals($string, './srv');
+    }
+
+    public function test_generates_with_an_explicit_relative_containing_a_directory() {
+        $path = new Path('./srv/sub');
+        $string = $path->string();
+        $this->assertEquals($string, './srv/sub');
+    }
+
+    public function test_generates_with_an_explicit_relative_containing_a_file() {
+        $path = new Path('./srv/file.json');
+        $string = $path->string();
+        $this->assertEquals($string, './srv/file.json');
+    }
+
+    public function test_generates_with_an_explicit_relative_containing_a_directory_with_a_file() {
+        $path = new Path('./srv/sub/file.json');
+        $string = $path->string();
+        $this->assertEquals($string, './srv/sub/file.json');
+    }
+
+    public function test_generates_with_an_explicit_unnormalized_relative() {
+        $path = new Path('./srv////sub///file.json');
+        $string = $path->string();
+        $this->assertEquals($string, './srv////sub///file.json');
+    }
+
+    public function test_generates_with_an_explicit_normalized_relative() {
+        $path = new Path('./srv////sub///file.json');
+        $normalized = $path->normalize();
+        $string = $normalized->string();
+        $this->assertEquals($string, 'srv/sub/file.json');
+    }
+
+    public function test_generates_with_an_absolute() {
+        $path = new Path('/srv');
+        $string = $path->string();
+        $this->assertEquals($string, '/srv');
+    }
+
+    public function test_generates_with_an_absolute_containing_a_directory() {
+        $path = new Path('/srv/sub');
+        $string = $path->string();
+        $this->assertEquals($string, '/srv/sub');
+    }
+
+    public function test_generates_with_an_absolute_containing_a_file() {
+        $path = new Path('/srv/file.json');
+        $string = $path->string();
+        $this->assertEquals($string, '/srv/file.json');
+    }
+
+    public function test_generates_with_an_absolute_containing_a_directory_with_a_file() {
+        $path = new Path('/srv/sub/file.json');
+        $string = $path->string();
+        $this->assertEquals($string, '/srv/sub/file.json');
+    }
+
+    public function test_generates_with_an_unnormalized_absolute() {
+        $path = new Path('/srv////sub///file.json');
+        $string = $path->string();
+        $this->assertEquals($string, '/srv////sub///file.json');
+    }
+
+    public function test_generates_with_an_normalized_absolute() {
+        $path = new Path('/srv////sub///file.json');
+        $normalized = $path->normalize();
+        $string = $normalized->string();
+        $this->assertEquals($string, '/srv/sub/file.json');
+    }
+}


### PR DESCRIPTION
@rivexe, please take a look at my changes. I've added tests for the Path class, but they currently only cover systems with `/` in the path (macOS, Linux). However, on paper, the new methods should also work well with `\` (Windows). Currently, the Path class is only utilized in the restore endpoint, so I suggest trying to restore something. In the future, this class will be used in multiple locations, so if I have overlooked anything while implementing these methods, we will see it.

Continuation of #421.