### PR TITLE
php: many changes to satisfy linter

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -26,4 +26,4 @@ jobs:
           tools: cs2pr, phpcs
           
       - name: Lint
-        run: phpcs .
+        run: phpcs src index.php

--- a/web/documentserver-example/php/Makefile
+++ b/web/documentserver-example/php/Makefile
@@ -63,7 +63,7 @@ compose-prod: #  Up containers in a production environment.
 
 .PHONY: lint
 lint: #          Lint the source code for the style.
-	@./vendor/bin/phpcs .
+	@./vendor/bin/phpcs src index.php
 
 .PHONY: test
 test: #          Run tests recursively.

--- a/web/documentserver-example/php/index.php
+++ b/web/documentserver-example/php/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects.FoundWithSymbols
 /**
  * (c) Copyright Ascensio System SIA 2023
  *
@@ -28,9 +28,10 @@ use Example\Configuration\ConfigurationManager;
 use Example\Views\DocEditorView;
 use Example\Views\IndexView;
 
-function configure() {
-    $config_manager = new ConfigurationManager();
-    if ($config_manager->ssl_verify_peer_mode_enabled()) {
+function configure()
+{
+    $configManager = new ConfigurationManager();
+    if ($configManager->sslVerifyPeerModeEnabled()) {
         // Ignore self-signed certificate.
         stream_context_set_default([
             'ssl' => [
@@ -41,7 +42,8 @@ function configure() {
     }
 }
 
-function routers() {
+function routers()
+{
     // TODO: delete fallback.
     // In theory, the content type of the response should be declared inside the
     // router function. However, this statement isn't true for all routers, and
@@ -149,7 +151,7 @@ function routers() {
         return;
     }
 
-    http_response_code(HTTPStatus::not_found->value);
+    http_response_code(HTTPStatus::NotFound->value);
 }
 
 configure();

--- a/web/documentserver-example/php/phpcs.xml
+++ b/web/documentserver-example/php/phpcs.xml
@@ -10,4 +10,13 @@
       <property name="absoluteLineLimit" value="0"/>
     </properties>
   </rule>
+
+  <rule ref="Squiz.NamingConventions.ValidVariableName"/>
+
+  <rule ref="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
+    <severity>0</severity>
+  </rule>
 </ruleset>

--- a/web/documentserver-example/php/src/ajax.php
+++ b/web/documentserver-example/php/src/ajax.php
@@ -57,7 +57,7 @@ function getHttpOrigin()
 function saveas()
 {
     try {
-        $config_manager = new ConfigurationManager();
+        $configManager = new ConfigurationManager();
         $formatManager = new FormatManager();
 
         $post = json_decode(file_get_contents('php://input'), true);
@@ -72,10 +72,10 @@ function saveas()
             return $result;
         }
         $headers = get_headers($fileurl, 1);
-        $content_length = $headers["Content-Length"];
+        $contentLength = $headers["Content-Length"];
         $data = file_get_contents(str_replace(" ", "%20", $fileurl));
 
-        if ($data === false || $content_length <= 0 || $content_length > $config_manager->maximum_file_size()) {
+        if ($data === false || $contentLength <= 0 || $contentLength > $configManager->maximumFileSize()) {
             $result["error"] = "File size is incorrect";
             return $result;
         }
@@ -101,7 +101,7 @@ function saveas()
  */
 function upload()
 {
-    $config_manager = new ConfigurationManager();
+    $configManager = new ConfigurationManager();
     $formatManager = new FormatManager();
 
     if ($_FILES['files']['error'] > 0) {
@@ -124,7 +124,7 @@ function upload()
         $ext = mb_strtolower(pathinfo($_FILES['files']['name'], PATHINFO_EXTENSION));  // get file extension
 
         // check if the file size is correct (it should be less than the max file size, but greater than 0)
-        if ($filesize <= 0 || $filesize > $config_manager->maximum_file_size()) {
+        if ($filesize <= 0 || $filesize > $configManager->maximumFileSize()) {
             $result["error"] = 'File size is incorrect';  // if not, then an error occurs
             return $result;
         }
@@ -173,7 +173,7 @@ function track()
         return $data;
     }
 
-    $_trackerStatus = [
+    $trackerStatus = [
         0 => 'NotFound',
         1 => 'Editing',
         2 => 'MustSave',
@@ -182,7 +182,7 @@ function track()
         6 => 'MustForceSave',
         7 => 'CorruptedForceSave',
     ];
-    $status = $_trackerStatus[$data->status];  // get status from the request body
+    $status = $trackerStatus[$data->status];  // get status from the request body
 
     $userAddress = $_GET["userAddress"];
     $fileName = basename($_GET["fileName"]);
@@ -369,7 +369,7 @@ function csv()
 function historyDownload()
 {
     try {
-        $config_manager = new ConfigurationManager();
+        $configManager = new ConfigurationManager();
 
         $fileName = basename($_GET["fileName"]);  // get the file name
         $userAddress = $_GET["userAddress"];
@@ -379,7 +379,7 @@ function historyDownload()
 
         $jwtManager = new JwtManager();
         if ($jwtManager->isJwtEnabled()) {
-            $jwtHeader = $config_manager->jwt_header();
+            $jwtHeader = $configManager->jwtHeader();
             if (!empty(apache_request_headers()[$jwtHeader])) {
                 $token = $jwtManager->jwtDecode(mb_substr(
                     apache_request_headers()[$jwtHeader],
@@ -416,7 +416,7 @@ function historyDownload()
 function download()
 {
     try {
-        $config_manager = new ConfigurationManager();
+        $configManager = new ConfigurationManager();
 
         $fileName = $_GET["fileName"];
         $userAddress = $_GET["userAddress"] ?? null;
@@ -424,7 +424,7 @@ function download()
         $jwtManager = new JwtManager();
 
         if ($jwtManager->isJwtEnabled() && $isEmbedded == null && $userAddress) {
-            $jwtHeader = $config_manager->jwt_header();
+            $jwtHeader = $configManager->jwtHeader();
             if (!empty(apache_request_headers()[$jwtHeader])) {
                 $token = $jwtManager->jwtDecode(mb_substr(
                     apache_request_headers()[$jwtHeader],
@@ -464,7 +464,10 @@ function downloadFile($filePath)
 
         // write headers to the response object
         @header('Content-Length: ' . filesize($filePath));
-        @header('Content-Disposition: attachment; filename*=UTF-8\'\'' . str_replace("+", "%20", urlencode(basename($filePath))));
+        @header(
+            'Content-Disposition: attachment; filename*=UTF-8\'\'' .
+            str_replace("+", "%20", urlencode(basename($filePath)))
+        );
         @header('Content-Type: ' . mime_content_type($filePath));
         @header('Access-Control-Allow-Origin: *');
 
@@ -588,31 +591,31 @@ function restore()
         $input = file_get_contents('php://input');
         $body = json_decode($input);
 
-        $source_basename = $body->fileName;
+        $sourceBasename = $body->fileName;
         $version = $body->version;
-        $user_id = $body->userId;
+        $userID = $body->userId;
 
-        $source_file = getStoragePath($source_basename);
-        $history_directory = getHistoryDir($source_file);
+        $sourceFile = getStoragePath($sourceBasename);
+        $historyDirectory = getHistoryDir($sourceFile);
 
-        $bumped_version = getFileVersion($history_directory);
-        $bumped_version_string_directory = getVersionDir($history_directory, $bumped_version);
-        if (!file_exists($bumped_version_string_directory)) {
-            mkdir($bumped_version_string_directory);
+        $bumpedVersion = getFileVersion($historyDirectory);
+        $bumpedVersionStringDirectory = getVersionDir($historyDirectory, $bumpedVersion);
+        if (!file_exists($bumpedVersionStringDirectory)) {
+            mkdir($bumpedVersionStringDirectory);
         }
-        $bumped_version_directory = new Path($bumped_version_string_directory);
+        $bumpedVersionDirectory = new Path($bumpedVersionStringDirectory);
 
-        $bumped_key_file = $bumped_version_directory->join_path('key.txt');
-        $bumped_key_string_file = $bumped_key_file->string();
-        $bumped_key = getDocEditorKey($source_basename);
-        file_put_contents($bumped_key_string_file, $bumped_key, LOCK_EX);
+        $bumpedKeyFile = $bumpedVersionDirectory->joinPath('key.txt');
+        $bumpedKeyStringFile = $bumpedKeyFile->string();
+        $bumpedKey = getDocEditorKey($sourceBasename);
+        file_put_contents($bumpedKeyStringFile, $bumpedKey, LOCK_EX);
 
         $users = new ExampleUsers();
-        $user = $users->getUser($user_id);
+        $user = $users->getUser($userID);
 
-        $bumped_changes_file = $bumped_version_directory->join_path('changes.json');
-        $bumped_changes_string_file = $bumped_changes_file->string();
-        $bumped_changes = [
+        $bumpedChangesFile = $bumpedVersionDirectory->joinPath('changes.json');
+        $bumpedChangesStringFile = $bumpedChangesFile->string();
+        $bumpedChanges = [
             'serverVersion' => null,
             'changes' => array(
                 [
@@ -624,21 +627,21 @@ function restore()
                 ]
             )
         ];
-        $bumped_changes_content = json_encode($bumped_changes, JSON_PRETTY_PRINT);
-        file_put_contents($bumped_changes_string_file, $bumped_changes_content, LOCK_EX);
+        $bumpedChangesContent = json_encode($bumpedChanges, JSON_PRETTY_PRINT);
+        file_put_contents($bumpedChangesStringFile, $bumpedChangesContent, LOCK_EX);
 
-        $source_extension = pathinfo($source_basename, PATHINFO_EXTENSION);
-        $previous_basename = "prev.{$source_extension}";
+        $sourceExtension = pathinfo($sourceBasename, PATHINFO_EXTENSION);
+        $previousBasename = "prev.{$sourceExtension}";
 
-        $bumped_file = $bumped_version_directory->join_path($previous_basename);
-        $bumped_string_file = $bumped_file->string();
-        copy($source_file, $bumped_string_file);
+        $bumpedFile = $bumpedVersionDirectory->joinPath($previousBasename);
+        $bumpedStringFile = $bumpedFile->string();
+        copy($sourceFile, $bumpedStringFile);
 
-        $recovery_version_string_directory = getVersionDir($history_directory, $version);
-        $recovery_version_directory = new Path($recovery_version_string_directory);
-        $recovery_file = $recovery_version_directory->join_path($previous_basename);
-        $recovery_string_file = $recovery_file->string();
-        copy($recovery_string_file, $source_file);
+        $recoveryVersionStringDirectory = getVersionDir($historyDirectory, $version);
+        $recoveryVersionDirectory = new Path($recoveryVersionStringDirectory);
+        $recoveryFile = $recoveryVersionDirectory->joinPath($previousBasename);
+        $recoveryStringFile = $recoveryFile->string();
+        copy($recoveryStringFile, $sourceFile);
 
         return [
             'error' => null,

--- a/web/documentserver-example/php/src/common/HTTPStatus.php
+++ b/web/documentserver-example/php/src/common/HTTPStatus.php
@@ -17,6 +17,7 @@
 
 namespace Example\Common;
 
-enum HTTPStatus: int {
-    case not_found = 404;
+enum HTTPStatus: int
+{
+    case NotFound = 404;
 }

--- a/web/documentserver-example/php/src/common/Path.php
+++ b/web/documentserver-example/php/src/common/Path.php
@@ -17,43 +17,51 @@
 
 namespace Example\Common;
 
-class Path {
+final class Path
+{
     private string $separator = DIRECTORY_SEPARATOR;
     private string $string;
 
-    public function __construct(string $path) {
+    public function __construct(string $path)
+    {
         $this->string = $path;
     }
 
-    public function string(): string {
+    public function string(): string
+    {
         return $this->string;
     }
 
-    public function dirname(): ?string {
+    public function dirname(): ?string
+    {
         $string = $this->string();
         $parsed = pathinfo($string, PATHINFO_DIRNAME);
         return $parsed ?: null;
     }
 
-    public function basename(): ?string {
+    public function basename(): ?string
+    {
         $string = $this->string();
         $parsed = pathinfo($string, PATHINFO_BASENAME);
         return $parsed ?: null;
     }
 
-    public function extension(): ?string {
+    public function extension(): ?string
+    {
         $string = $this->string();
         $parsed = pathinfo($string, PATHINFO_EXTENSION);
         return $parsed ?: null;
     }
 
-    public function filename(): ?string {
+    public function filename(): ?string
+    {
         $string = $this->string();
         $parsed = pathinfo($string, PATHINFO_FILENAME);
         return $parsed ?: null;
     }
 
-    public function normalize(): self {
+    public function normalize(): self
+    {
         $string = $this->string();
         $filtered = array();
         $slugs = explode($this->separator, $string);
@@ -68,13 +76,14 @@ class Path {
             $filtered[] = $slug;
         }
         $joined = implode($this->separator, $filtered);
-        $escaped_separator = preg_quote($this->separator, $this->separator);
-        $separator_regex = "/{$escaped_separator}{2,}/";
-        $separated = preg_replace($separator_regex, $this->separator, $joined);
+        $escapedSeparator = preg_quote($this->separator, $this->separator);
+        $separatorRegex = "/{$escapedSeparator}{2,}/";
+        $separated = preg_replace($separatorRegex, $this->separator, $joined);
         return new Path($separated);
     }
 
-    public function join_path(string $path): self {
+    public function joinPath(string $path): self
+    {
         $string = $this->string();
         $separator =
             str_ends_with($string, $this->separator) ||
@@ -84,43 +93,48 @@ class Path {
         return new Path("{$string}{$separator}{$path}");
     }
 
-    public function absolute(): bool {
+    public function absolute(): bool
+    {
         $string = $this->string();
 
-        $nt_regex = '/^[A-Za-z]:\\\\/';
-        if (preg_match($nt_regex, $string)) {
+        $ntRegex = '/^[A-Za-z]:\\\\/';
+        if (preg_match($ntRegex, $string)) {
             return true;
         }
 
-        $nt_separator = '\\';
-        if (str_starts_with($string, $nt_separator)) {
+        $ntSeparator = '\\';
+        if (str_starts_with($string, $ntSeparator)) {
             return true;
         }
 
-        $posix_separator = '/';
-        if (str_starts_with($string, $posix_separator)) {
+        $posixSeparator = '/';
+        if (str_starts_with($string, $posixSeparator)) {
             return true;
         }
 
         return false;
     }
 
-    public function exists(): bool {
+    public function exists(): bool
+    {
         $string = $this->string();
         return file_exists($string);
     }
 
-    public function contents(): string {
+    public function contents(): string
+    {
         $string = $this->string();
         return file_get_contents($string);
     }
 
-    public function directory(): bool {
+    public function directory(): bool
+    {
         $string = $this->string();
         return is_dir($string);
     }
 
-    public function make_directory(): bool {
+    public function makeDirectory(): bool
+    {
         $string = $this->string();
         return mkdir($string);
     }

--- a/web/documentserver-example/php/src/common/PathAbsolutePOSIXTests.php
+++ b/web/documentserver-example/php/src/common/PathAbsolutePOSIXTests.php
@@ -15,23 +15,29 @@
 // limitations under the License.
 //
 
+namespace Example\Common\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Common\Path;
 
-final class PathAbsolutePOSIXTests extends TestCase {
-    public function test_recognizes_an_empty_as_a_non_absolute() {
+final class PathAbsolutePOSIXTests extends TestCase
+{
+    public function testRecognizesAnEmptyAsANonAbsolute()
+    {
         $path = new Path('');
         $absolute = $path->absolute();
         $this->assertFalse($absolute);
     }
 
-    public function test_recognizes_a_relative_as_a_non_absolute() {
+    public function testRecognizesARelativeAsANonAbsolute()
+    {
         $path = new Path('.');
         $absolute = $path->absolute();
         $this->assertFalse($absolute);
     }
 
-    public function test_recognizes_an_absolute_as_an_absolute() {
+    public function testRecognizesAnAbsoluteAsAnAbsolute()
+    {
         $path = new Path('/');
         $absolute = $path->absolute();
         $this->assertTrue($absolute);

--- a/web/documentserver-example/php/src/common/PathJoinPOSIXTests.php
+++ b/web/documentserver-example/php/src/common/PathJoinPOSIXTests.php
@@ -15,67 +15,77 @@
 // limitations under the License.
 //
 
+namespace Example\Common\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Common\Path;
 
-final class PathJoinPOSIXTests extends TestCase {
-    public function test_joins_a_relative_to_an_empty_one() {
+final class PathJoinPOSIXTests extends TestCase
+{
+    public function testJoinsARelativeToAnEmptyOne()
+    {
         $path = new Path('');
-        $joined = $path->join_path('srv');
+        $joined = $path->joinPath('srv');
         $this->assertEquals($joined->dirname(), '/');
         $this->assertEquals($joined->basename(), 'srv');
         $this->assertEquals($joined->extension(), null);
         $this->assertEquals($joined->filename(), 'srv');
     }
 
-    public function test_joins_a_relative_to_a_relative_one() {
+    public function testJoinsARelativeToARelativeOne()
+    {
         $path = new Path('.');
-        $joined = $path->join_path('srv');
+        $joined = $path->joinPath('srv');
         $this->assertEquals($joined->dirname(), '.');
         $this->assertEquals($joined->basename(), 'srv');
         $this->assertEquals($joined->extension(), null);
         $this->assertEquals($joined->filename(), 'srv');
     }
 
-    public function test_joins_a_relative_to_an_absolute_one() {
+    public function testJoinsARelativeToAnAbsoluteOne()
+    {
         $path = new Path('/');
-        $joined = $path->join_path('srv');
+        $joined = $path->joinPath('srv');
         $this->assertEquals($joined->dirname(), '/');
         $this->assertEquals($joined->basename(), 'srv');
         $this->assertEquals($joined->extension(), null);
         $this->assertEquals($joined->filename(), 'srv');
     }
 
-    public function test_joins_an_absolute_to_an_empty_one() {
+    public function testJoinsAnAbsoluteToAnEmptyOne()
+    {
         $path = new Path('');
-        $joined = $path->join_path('/srv');
+        $joined = $path->joinPath('/srv');
         $this->assertEquals($joined->dirname(), '/');
         $this->assertEquals($joined->basename(), 'srv');
         $this->assertEquals($joined->extension(), null);
         $this->assertEquals($joined->filename(), 'srv');
     }
 
-    public function test_joins_an_absolute_to_a_relative_one() {
+    public function testJoinsAnAbsoluteToARelativeOne()
+    {
         $path = new Path('.');
-        $joined = $path->join_path('/srv');
+        $joined = $path->joinPath('/srv');
         $this->assertEquals($joined->dirname(), '.');
         $this->assertEquals($joined->basename(), 'srv');
         $this->assertEquals($joined->extension(), null);
         $this->assertEquals($joined->filename(), 'srv');
     }
 
-    public function test_joins_an_absolute_to_an_absolute_one() {
+    public function testJoinsAnAbsoluteToAnAbsoluteOne()
+    {
         $path = new Path('/');
-        $joined = $path->join_path('/srv');
+        $joined = $path->joinPath('/srv');
         $this->assertEquals($joined->dirname(), '/');
         $this->assertEquals($joined->basename(), 'srv');
         $this->assertEquals($joined->extension(), null);
         $this->assertEquals($joined->filename(), 'srv');
     }
 
-    public function test_joins_an_unnormalized() {
+    public function testJoinsAnUnnormalized()
+    {
         $path = new Path('');
-        $joined = $path->join_path('../srv');
+        $joined = $path->joinPath('../srv');
         $this->assertEquals($joined->dirname(), '/..');
         $this->assertEquals($joined->basename(), 'srv');
         $this->assertEquals($joined->extension(), null);

--- a/web/documentserver-example/php/src/common/PathNormalizePOSIXTests.php
+++ b/web/documentserver-example/php/src/common/PathNormalizePOSIXTests.php
@@ -15,11 +15,15 @@
 // limitations under the License.
 //
 
+namespace Example\Common\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Common\Path;
 
-final class PathNormalizePOSIXTests extends TestCase {
-    public function test_normalizes() {
+final class PathNormalizePOSIXTests extends TestCase
+{
+    public function testNormalizes()
+    {
         $path = new Path('./srv///sub/.././sub/file.docx');
         $normalized = $path->normalize();
         $this->assertEquals($normalized->dirname(), 'srv/sub');

--- a/web/documentserver-example/php/src/common/PathStringPOSIXTests.php
+++ b/web/documentserver-example/php/src/common/PathStringPOSIXTests.php
@@ -15,133 +15,157 @@
 // limitations under the License.
 //
 
+namespace Example\Common\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Common\Path;
 
-final class PathStringPOSIXTests extends TestCase {
-    public function test_generates_with_an_empty() {
+final class PathStringPOSIXTests extends TestCase
+{
+    public function testGeneratesWithAnEmpty()
+    {
         $path = new Path('');
         $string = $path->string();
         $this->assertEquals($string, '');
     }
 
-    public function test_generates_with_an_empty_relative() {
+    public function testGeneratesWithAnEmptyRelative()
+    {
         $path = new Path('.');
         $string = $path->string();
         $this->assertEquals($string, '.');
     }
 
-    public function test_generates_with_an_empty_absolute() {
+    public function testGeneratesWithAnEmptyAbsolute()
+    {
         $path = new Path('/');
         $string = $path->string();
         $this->assertEquals($string, '/');
     }
 
-    public function test_generates_with_a_relative() {
+    public function testGeneratesWithARelative()
+    {
         $path = new Path('srv');
         $string = $path->string();
         $this->assertEquals($string, 'srv');
     }
 
-    public function test_generates_with_a_relative_containing_a_directory() {
+    public function testGeneratesWithARelativeContainingADirectory()
+    {
         $path = new Path('srv/sub');
         $string = $path->string();
         $this->assertEquals($string, 'srv/sub');
     }
 
-    public function test_generates_with_a_relative_containing_a_file() {
+    public function testGeneratesWithARelativeContainingAFile()
+    {
         $path = new Path('srv/file.json');
         $string = $path->string();
         $this->assertEquals($string, 'srv/file.json');
     }
 
-    public function test_generates_with_a_relative_containing_a_directory_with_a_file() {
+    public function testGeneratesWithARelativeContainingADirectoryWithAFile()
+    {
         $path = new Path('srv/sub/file.json');
         $string = $path->string();
         $this->assertEquals($string, 'srv/sub/file.json');
     }
 
-    public function test_generates_with_an_unnormalized_relative() {
+    public function testGeneratesWithAnUnnormalizedRelative()
+    {
         $path = new Path('srv////sub///file.json');
         $string = $path->string();
         $this->assertEquals($string, 'srv////sub///file.json');
     }
 
-    public function test_generates_with_an_normalized_relative() {
+    public function testGeneratesWithAnNormalizedRelative()
+    {
         $path = new Path('srv////sub///file.json');
         $normalized = $path->normalize();
         $string = $normalized->string();
         $this->assertEquals($string, 'srv/sub/file.json');
     }
 
-    public function test_generates_with_an_explicit_relative() {
+    public function testGeneratesWithAnExplicitRelative()
+    {
         $path = new Path('./srv');
         $string = $path->string();
         $this->assertEquals($string, './srv');
     }
 
-    public function test_generates_with_an_explicit_relative_containing_a_directory() {
+    public function testGeneratesWithAnExplicitRelativeContainingADirectory()
+    {
         $path = new Path('./srv/sub');
         $string = $path->string();
         $this->assertEquals($string, './srv/sub');
     }
 
-    public function test_generates_with_an_explicit_relative_containing_a_file() {
+    public function testGeneratesWithAnExplicitRelativeContainingAFile()
+    {
         $path = new Path('./srv/file.json');
         $string = $path->string();
         $this->assertEquals($string, './srv/file.json');
     }
 
-    public function test_generates_with_an_explicit_relative_containing_a_directory_with_a_file() {
+    public function testGeneratesWithAnExplicitRelativeContainingADirectoryWithAFile()
+    {
         $path = new Path('./srv/sub/file.json');
         $string = $path->string();
         $this->assertEquals($string, './srv/sub/file.json');
     }
 
-    public function test_generates_with_an_explicit_unnormalized_relative() {
+    public function testGeneratesWithAnExplicitUnnormalizedRelative()
+    {
         $path = new Path('./srv////sub///file.json');
         $string = $path->string();
         $this->assertEquals($string, './srv////sub///file.json');
     }
 
-    public function test_generates_with_an_explicit_normalized_relative() {
+    public function testGeneratesWithAnExplicitNormalizedRelative()
+    {
         $path = new Path('./srv////sub///file.json');
         $normalized = $path->normalize();
         $string = $normalized->string();
         $this->assertEquals($string, 'srv/sub/file.json');
     }
 
-    public function test_generates_with_an_absolute() {
+    public function testGeneratesWithAnAbsolute()
+    {
         $path = new Path('/srv');
         $string = $path->string();
         $this->assertEquals($string, '/srv');
     }
 
-    public function test_generates_with_an_absolute_containing_a_directory() {
+    public function testGeneratesWithAnAbsoluteContainingADirectory()
+    {
         $path = new Path('/srv/sub');
         $string = $path->string();
         $this->assertEquals($string, '/srv/sub');
     }
 
-    public function test_generates_with_an_absolute_containing_a_file() {
+    public function testGeneratesWithAnAbsoluteContainingAFile()
+    {
         $path = new Path('/srv/file.json');
         $string = $path->string();
         $this->assertEquals($string, '/srv/file.json');
     }
 
-    public function test_generates_with_an_absolute_containing_a_directory_with_a_file() {
+    public function testGeneratesWithAnAbsoluteContainingADirectoryWithAFile()
+    {
         $path = new Path('/srv/sub/file.json');
         $string = $path->string();
         $this->assertEquals($string, '/srv/sub/file.json');
     }
 
-    public function test_generates_with_an_unnormalized_absolute() {
+    public function testGeneratesWithAnUnnormalizedAbsolute()
+    {
         $path = new Path('/srv////sub///file.json');
         $string = $path->string();
         $this->assertEquals($string, '/srv////sub///file.json');
     }
 
-    public function test_generates_with_an_normalized_absolute() {
+    public function testGeneratesWithAnNormalizedAbsolute()
+    {
         $path = new Path('/srv////sub///file.json');
         $normalized = $path->normalize();
         $string = $normalized->string();

--- a/web/documentserver-example/php/src/common/URL.php
+++ b/web/documentserver-example/php/src/common/URL.php
@@ -17,58 +17,69 @@
 
 namespace Example\Common;
 
-class URL {
+final class URL
+{
     private string $string;
 
-    public function __construct(string $url) {
+    public function __construct(string $url)
+    {
         $this->string = $url;
     }
 
-    public function string(): string {
+    public function string(): string
+    {
         return $this->string;
     }
 
-    public function scheme(): ?string {
+    public function scheme(): ?string
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_SCHEME) ?: null;
     }
 
-    public function host(): ?string {
+    public function host(): ?string
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_HOST) ?: null;
     }
 
-    public function port(): ?int {
+    public function port(): ?int
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_PORT) ?: null;
     }
 
-    public function user(): ?string {
+    public function user(): ?string
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_USER) ?: null;
     }
 
-    public function pass(): ?string {
+    public function pass(): ?string
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_PASS) ?: null;
     }
 
-    public function path(): ?string {
+    public function path(): ?string
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_PATH) ?: null;
     }
 
-    public function query(): ?string {
+    public function query(): ?string
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_QUERY) ?: null;
     }
 
-    public function fragment(): ?string {
+    public function fragment(): ?string
+    {
         $string = $this->string();
         return parse_url($string, PHP_URL_FRAGMENT) ?: null;
     }
 
-    public static function from_components(
+    public static function fromComponents(
         ?string $scheme,
         ?string $host,
         ?int $port,
@@ -106,19 +117,20 @@ class URL {
         return new URL($string);
     }
 
-    public function join_path(string $path): self {
-        $current_path = $this->path();
+    public function joinPath(string $path): self
+    {
+        $currentPath = $this->path();
         $separator =
-            $current_path &&
+            $currentPath &&
             (
-                str_ends_with($current_path, '/') ||
+                str_ends_with($currentPath, '/') ||
                 str_starts_with($path, '/')
             ) ||
-            !$current_path && str_starts_with($path, '/')
+            !$currentPath && str_starts_with($path, '/')
             ? ''
             : '/';
-        $separated = "{$current_path}{$separator}{$path}";
-        return URL::from_components(
+        $separated = "{$currentPath}{$separator}{$path}";
+        return URL::fromComponents(
             $this->scheme(),
             $this->host(),
             $this->port(),

--- a/web/documentserver-example/php/src/common/URLFromComponentsTests.php
+++ b/web/documentserver-example/php/src/common/URLFromComponentsTests.php
@@ -15,12 +15,16 @@
 // limitations under the License.
 //
 
+namespace Example\Common\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Common\URL;
 
-final class URLFromComponentsTests extends TestCase {
-    public function test_creates() {
-        $url = URL::from_components(
+final class URLFromComponentsTests extends TestCase
+{
+    public function testCreates()
+    {
+        $url = URL::fromComponents(
             'http',
             'localhost',
             8080,

--- a/web/documentserver-example/php/src/common/URLJoinPathTests.php
+++ b/web/documentserver-example/php/src/common/URLJoinPathTests.php
@@ -15,13 +15,17 @@
 // limitations under the License.
 //
 
+namespace Example\Common\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Common\URL;
 
-final class URLJoinPathTests extends TestCase {
-    public function test_joins_a_relative_to_an_empty_one() {
+final class URLJoinPathTests extends TestCase
+{
+    public function testJoinsARelativeToAnEmptyOne()
+    {
         $url = new URL('http://localhost');
-        $joined = $url->join_path('first');
+        $joined = $url->joinPath('first');
         $this->assertEquals('http', $joined->scheme());
         $this->assertEquals('localhost', $joined->host());
         $this->assertEquals(null, $joined->port());
@@ -32,9 +36,10 @@ final class URLJoinPathTests extends TestCase {
         $this->assertEquals(null, $joined->fragment());
     }
 
-    public function test_joins_a_relative() {
+    public function testJoinsARelative()
+    {
         $url = new URL('http://localhost/first');
-        $joined = $url->join_path('second');
+        $joined = $url->joinPath('second');
         $this->assertEquals('http', $joined->scheme());
         $this->assertEquals('localhost', $joined->host());
         $this->assertEquals(null, $joined->port());
@@ -45,9 +50,10 @@ final class URLJoinPathTests extends TestCase {
         $this->assertEquals(null, $joined->fragment());
     }
 
-    public function test_joins_an_absolute_to_an_empty_one() {
+    public function testJoinsAnAbsoluteToAnEmptyOne()
+    {
         $url = new URL('http://localhost');
-        $joined = $url->join_path('/first');
+        $joined = $url->joinPath('/first');
         $this->assertEquals('http', $joined->scheme());
         $this->assertEquals('localhost', $joined->host());
         $this->assertEquals(null, $joined->port());
@@ -58,9 +64,10 @@ final class URLJoinPathTests extends TestCase {
         $this->assertEquals(null, $joined->fragment());
     }
 
-    public function test_joins_an_absolute() {
+    public function testJoinsAnAbsolute()
+    {
         $url = new URL('http://localhost/first');
-        $joined = $url->join_path('/second');
+        $joined = $url->joinPath('/second');
         $this->assertEquals('http', $joined->scheme());
         $this->assertEquals('localhost', $joined->host());
         $this->assertEquals(null, $joined->port());

--- a/web/documentserver-example/php/src/common/URLStringTests.php
+++ b/web/documentserver-example/php/src/common/URLStringTests.php
@@ -15,11 +15,15 @@
 // limitations under the License.
 //
 
+namespace Example\Common\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Common\URL;
 
-final class URLStringTests extends TestCase {
-    public function test_generates() {
+final class URLStringTests extends TestCase
+{
+    public function testGenerates()
+    {
         $url = new URL('http://user:password@localhost:8080/path?q=value#fragment');
         $string = $url->string();
         $this->assertEquals(

--- a/web/documentserver-example/php/src/configuration/ConfigurationManager.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManager.php
@@ -20,10 +20,12 @@ namespace Example\Configuration;
 use Example\Common\Path;
 use Example\Common\URL;
 
-class ConfigurationManager {
+class ConfigurationManager
+{
     public string $version = '1.6.0';
 
-    public function example_url(): ?URL {
+    public function exampleURL(): ?URL
+    {
         $url = getenv('EXAMPLE_URL');
         if (!$url) {
             return null;
@@ -31,56 +33,65 @@ class ConfigurationManager {
         return new URL($url);
     }
 
-    public function document_server_public_url(): URL {
+    public function documentServerPublicURL(): URL
+    {
         $url = getenv('DOCUMENT_SERVER_PUBLIC_URL') ?: 'http://document-server';
         return new URL($url);
     }
 
-    public function document_server_private_url(): URL {
+    public function documentServerPrivateURL(): URL
+    {
         $url = getenv('DOCUMENT_SERVER_PRIVATE_URL');
         if (!$url) {
-            return $this->document_server_public_url();
+            return $this->documentServerPublicURL();
         }
         return new URL($url);
     }
 
-    public function document_server_api_url(): URL {
-        $server_url = $this->document_server_public_url();
+    public function documentServerAPIURL(): URL
+    {
+        $serverURL = $this->documentServerPublicURL();
         $path = getenv('DOCUMENT_SERVER_API_PATH')
             ?: 'web-apps/apps/api/documents/api.js';
-        return $server_url->join_path($path);
+        return $serverURL->joinPath($path);
     }
 
-    public function document_server_preloader_url(): URL {
-        $server_url = $this->document_server_public_url();
+    public function documentServerPreloaderURL(): URL
+    {
+        $serverURL = $this->documentServerPublicURL();
         $path = getenv('DOCUMENT_SERVER_PRELOADER_PATH')
             ?: 'web-apps/apps/api/documents/cache-scripts.html';
-        return $server_url->join_path($path);
+        return $serverURL->joinPath($path);
     }
 
-    public function document_server_command_url(): URL {
-        $server_url = $this->document_server_private_url();
+    public function documentServerCommandURL(): URL
+    {
+        $serverURL = $this->documentServerPrivateURL();
         $path = getenv('DOCUMENT_SERVER_COMMAND_PATH')
             ?: 'coauthoring/CommandService.ashx';
-        return $server_url->join_path($path);
+        return $serverURL->joinPath($path);
     }
 
-    public function document_server_converter_url(): URL {
-        $server_url = $this->document_server_private_url();
+    public function documentServerConverterURL(): URL
+    {
+        $serverURL = $this->documentServerPrivateURL();
         $path = getenv('DOCUMENT_SERVER_CONVERTER_PATH')
             ?: 'ConvertService.ashx';
-        return $server_url->join_path($path);
+        return $serverURL->joinPath($path);
     }
 
-    public function jwt_secret(): string {
+    public function jwtSecret(): string
+    {
         return getenv('JWT_SECRET') ?: '';
     }
 
-    public function jwt_header(): string {
+    public function jwtHeader(): string
+    {
         return getenv('JWT_HEADER') ?: 'Authorization';
     }
 
-    public function jwt_use_for_request(): bool {
+    public function jwtUseForRequest(): bool
+    {
         $use = getenv('JWT_USE_FOR_REQUEST');
         if (!$use) {
             return true;
@@ -88,7 +99,8 @@ class ConfigurationManager {
         return filter_var($use, FILTER_VALIDATE_BOOLEAN);
     }
 
-    public function ssl_verify_peer_mode_enabled(): bool {
+    public function sslVerifyPeerModeEnabled(): bool
+    {
         $enabled = getenv('SSL_VERIFY_PEER_MODE_ENABLED');
         if (!$enabled) {
             return false;
@@ -96,23 +108,25 @@ class ConfigurationManager {
         return filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
     }
 
-    public function storage_path(): Path {
-        $storage_path = getenv('STORAGE_PATH') ?: 'storage';
-        $storage_directory = new Path($storage_path);
-        if ($storage_directory->absolute()) {
-            return $storage_directory;
+    public function storagePath(): Path
+    {
+        $storagePath = getenv('STORAGE_PATH') ?: 'storage';
+        $storageDirectory = new Path($storagePath);
+        if ($storageDirectory->absolute()) {
+            return $storageDirectory;
         }
 
-        $storage_string_directory = $storage_directory->string();
-        $current_directory = new Path(__DIR__);
-        $directory = $current_directory
-            ->join_path('..')
-            ->join_path('..')
-            ->join_path($storage_string_directory);
+        $storageStringDirectory = $storageDirectory->string();
+        $currentDirectory = new Path(__DIR__);
+        $directory = $currentDirectory
+            ->joinPath('..')
+            ->joinPath('..')
+            ->joinPath($storageStringDirectory);
         return $directory->normalize();
     }
 
-    public function single_user(): bool {
+    public function singleUser(): bool
+    {
         $single = getenv('SINGLE_USER');
         if (!$single) {
             return false;
@@ -120,7 +134,8 @@ class ConfigurationManager {
         return filter_var($single, FILTER_VALIDATE_BOOLEAN);
     }
 
-    public function maximum_file_size(): int {
+    public function maximumFileSize(): int
+    {
         $size = getenv('MAXIMUM_FILE_SIZE');
         if (!$size) {
             return 5 * 1024 * 1024;
@@ -128,7 +143,8 @@ class ConfigurationManager {
         return intval($size);
     }
 
-    public function conversion_timeout(): int {
+    public function conversionTimeout(): int
+    {
         $timeout = getenv('CONVERSION_TIMEOUT');
         if (!$timeout) {
             return 120 * 1000;
@@ -139,7 +155,8 @@ class ConfigurationManager {
     /**
      * @return string[]
      */
-    public function languages(): array {
+    public function languages(): array
+    {
         return [
             'en' => "English",
             'hy' => 'Armenian',

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerConversionTimeoutTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerConversionTimeoutTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerConversionTimeoutTests extends TestCase {
+final class ConfigurationManagerConversionTimeoutTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $timeout = $config_manager->conversion_timeout();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $timeout = $configManager->conversionTimeout();
         $this->assertEquals(120_000, $timeout);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('CONVERSION_TIMEOUT=10');
-        $config_manager = new ConfigurationManager();
-        $timeout = $config_manager->conversion_timeout();
+        $configManager = new ConfigurationManager();
+        $timeout = $configManager->conversionTimeout();
         $this->assertEquals(10, $timeout);
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerAPIURLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerAPIURLTests.php
@@ -15,36 +15,43 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerDocumentServerAPIURLTests extends TestCase {
+final class ConfigurationManagerDocumentServerAPIURLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_api_url();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerAPIURL();
         $this->assertEquals(
             'http://document-server/web-apps/apps/api/documents/api.js',
             $url->string()
         );
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('DOCUMENT_SERVER_API_PATH=/api');
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_api_url();
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerAPIURL();
         $this->assertEquals(
             'http://document-server/api',
             $url->string()

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerCommandURLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerCommandURLTests.php
@@ -15,36 +15,43 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerDocumentServerCommandURLTests extends TestCase {
+final class ConfigurationManagerDocumentServerCommandURLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_command_url();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerCommandURL();
         $this->assertEquals(
             'http://document-server/coauthoring/CommandService.ashx',
             $url->string()
         );
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('DOCUMENT_SERVER_COMMAND_PATH=/command');
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_command_url();
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerCommandURL();
         $this->assertEquals(
             'http://document-server/command',
             $url->string()

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerConverterURLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerConverterURLTests.php
@@ -15,36 +15,43 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerDocumentServerConverterURLTests extends TestCase {
+final class ConfigurationManagerDocumentServerConverterURLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_converter_url();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerConverterURL();
         $this->assertEquals(
             'http://document-server/ConvertService.ashx',
             $url->string()
         );
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('DOCUMENT_SERVER_CONVERTER_PATH=/converter');
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_converter_url();
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerConverterURL();
         $this->assertEquals(
             'http://document-server/converter',
             $url->string()

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerPreloaderURLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerPreloaderURLTests.php
@@ -15,36 +15,43 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerDocumentServerPreloaderURLTests extends TestCase {
+final class ConfigurationManagerDocumentServerPreloaderURLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_preloader_url();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerPreloaderURL();
         $this->assertEquals(
             'http://document-server/web-apps/apps/api/documents/cache-scripts.html',
             $url->string()
         );
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('DOCUMENT_SERVER_PRELOADER_PATH=/preloader');
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_preloader_url();
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerPreloaderURL();
         $this->assertEquals(
             'http://document-server/preloader',
             $url->string()

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerPrivateURLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerPrivateURLTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerDocumentServerPrivateURLTests extends TestCase {
+final class ConfigurationManagerDocumentServerPrivateURLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_private_url();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerPrivateURL();
         $this->assertEquals('http://document-server', $url->string());
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('DOCUMENT_SERVER_PRIVATE_URL=http://localhost');
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_private_url();
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerPrivateURL();
         $this->assertEquals('http://localhost', $url->string());
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerPublicURLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerDocumentServerPublicURLTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerDocumentServerPublicURLTests extends TestCase {
+final class ConfigurationManagerDocumentServerPublicURLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_public_url();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerPublicURL();
         $this->assertEquals('http://document-server', $url->string());
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('DOCUMENT_SERVER_PUBLIC_URL=http://localhost');
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->document_server_public_url();
+        $configManager = new ConfigurationManager();
+        $url = $configManager->documentServerPublicURL();
         $this->assertEquals('http://localhost', $url->string());
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerExampleURLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerExampleURLTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerExampleURLTests extends TestCase {
+final class ConfigurationManagerExampleURLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->example_url();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $url = $configManager->exampleURL();
         $this->assertNull($url);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('EXAMPLE_URL=http://localhost');
-        $config_manager = new ConfigurationManager();
-        $url = $config_manager->example_url();
+        $configManager = new ConfigurationManager();
+        $url = $configManager->exampleURL();
         $this->assertEquals('http://localhost', $url->string());
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerJWTHeaderTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerJWTHeaderTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerJWTHeaderTests extends TestCase {
+final class ConfigurationManagerJWTHeaderTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $header = $config_manager->jwt_header();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $header = $configManager->jwtHeader();
         $this->assertEquals('Authorization', $header);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('JWT_HEADER=Proxy-Authorization');
-        $config_manager = new ConfigurationManager();
-        $header = $config_manager->jwt_header();
+        $configManager = new ConfigurationManager();
+        $header = $configManager->jwtHeader();
         $this->assertEquals('Proxy-Authorization', $header);
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerJWTSecretTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerJWTSecretTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerJWTSecretTests extends TestCase {
+final class ConfigurationManagerJWTSecretTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $secret = $config_manager->jwt_secret();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $secret = $configManager->jwtSecret();
         $this->assertEquals('', $secret);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('JWT_SECRET=your-256-bit-secret');
-        $config_manager = new ConfigurationManager();
-        $secret = $config_manager->jwt_secret();
+        $configManager = new ConfigurationManager();
+        $secret = $configManager->jwtSecret();
         $this->assertEquals('your-256-bit-secret', $secret);
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerJWTUseForRequest.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerJWTUseForRequest.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerJWTUseForRequest extends TestCase {
+final class ConfigurationManagerJWTUseForRequest extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $use = $config_manager->jwt_use_for_request();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $use = $configManager->jwtUseForRequest();
         $this->assertTrue($use);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('JWT_USE_FOR_REQUEST=false');
-        $config_manager = new ConfigurationManager();
-        $use = $config_manager->jwt_use_for_request();
+        $configManager = new ConfigurationManager();
+        $use = $configManager->jwtUseForRequest();
         $this->assertFalse($use);
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerMaximumFileSizeTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerMaximumFileSizeTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerMaximumFileSizeTests extends TestCase {
+final class ConfigurationManagerMaximumFileSizeTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $size = $config_manager->maximum_file_size();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $size = $configManager->maximumFileSize();
         $this->assertEquals(5_242_880, $size);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('MAXIMUM_FILE_SIZE=10');
-        $config_manager = new ConfigurationManager();
-        $size = $config_manager->maximum_file_size();
+        $configManager = new ConfigurationManager();
+        $size = $configManager->maximumFileSize();
         $this->assertEquals(10, $size);
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerSSLTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerSSLTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerSSLTests extends TestCase {
+final class ConfigurationManagerSSLTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $enabled = $config_manager->ssl_verify_peer_mode_enabled();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $enabled = $configManager->sslVerifyPeerModeEnabled();
         $this->assertFalse($enabled);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('SSL_VERIFY_PEER_MODE_ENABLED=true');
-        $config_manager = new ConfigurationManager();
-        $enabled = $config_manager->ssl_verify_peer_mode_enabled();
+        $configManager = new ConfigurationManager();
+        $enabled = $configManager->sslVerifyPeerModeEnabled();
         $this->assertTrue($enabled);
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerSingleUserTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerSingleUserTests.php
@@ -15,33 +15,40 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerSingleUserTests extends TestCase {
+final class ConfigurationManagerSingleUserTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $single = $config_manager->single_user();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $single = $configManager->singleUser();
         $this->assertFalse($single);
     }
 
-    public function test_assigns_a_value_from_the_environment() {
+    public function testAssignsAValueFromTheEnvironment()
+    {
         putenv('SINGLE_USER=true');
-        $config_manager = new ConfigurationManager();
-        $single = $config_manager->single_user();
+        $configManager = new ConfigurationManager();
+        $single = $configManager->singleUser();
         $this->assertTrue($single);
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerStoragePathTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerStoragePathTests.php
@@ -15,42 +15,50 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerStoragePathTests extends TestCase {
+final class ConfigurationManagerStoragePathTests extends TestCase
+{
     public array $env;
 
-    public function __construct(string $name) {
+    public function __construct(string $name)
+    {
         $this->env = getenv();
         parent::__construct($name);
     }
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         foreach ($this->env as $key => $value) {
             putenv("{$key}={$value}");
         }
     }
 
-    public function test_assigns_a_default_value() {
-        $config_manager = new ConfigurationManager();
-        $path = $config_manager->storage_path();
+    public function testAssignsADefaultValue()
+    {
+        $configManager = new ConfigurationManager();
+        $path = $configManager->storagePath();
         $this->assertTrue($path->absolute());
         $this->assertEquals($path->basename(), 'storage');
     }
 
-    public function test_assigns_a_relative_path_from_the_environment() {
+    public function testAssignsARelativePathFromTheEnvironment()
+    {
         putenv('STORAGE_PATH=directory');
-        $config_manager = new ConfigurationManager();
-        $path = $config_manager->storage_path();
+        $configManager = new ConfigurationManager();
+        $path = $configManager->storagePath();
         $this->assertTrue($path->absolute());
         $this->assertEquals($path->basename(), 'directory');
     }
 
-    public function test_assigns_an_absolute_path_from_the_environment() {
+    public function testAssignsAnAbsolutePathFromTheEnvironment()
+    {
         putenv('STORAGE_PATH=/directory');
-        $config_manager = new ConfigurationManager();
-        $path = $config_manager->storage_path();
+        $configManager = new ConfigurationManager();
+        $path = $configManager->storagePath();
         $this->assertEquals($path->string(), '/directory');
     }
 }

--- a/web/documentserver-example/php/src/configuration/ConfigurationManagerTests.php
+++ b/web/documentserver-example/php/src/configuration/ConfigurationManagerTests.php
@@ -15,12 +15,16 @@
 // limitations under the License.
 //
 
+namespace Example\Configuration\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
 
-final class ConfigurationManagerTests extends TestCase {
-    public function test_corresponds_the_latest_version() {
-        $config_manager = new ConfigurationManager();
-        $this->assertEquals('1.6.0', $config_manager->version);
+final class ConfigurationManagerTests extends TestCase
+{
+    public function testCorrespondsTheLatestVersion()
+    {
+        $configManager = new ConfigurationManager();
+        $this->assertEquals('1.6.0', $configManager->version);
     }
 }

--- a/web/documentserver-example/php/src/format/FormatManager.php
+++ b/web/documentserver-example/php/src/format/FormatManager.php
@@ -23,7 +23,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Example\Common\Path;
 
-final class FormatManager
+class FormatManager
 {
     private Serializer $serializer;
 
@@ -187,16 +187,16 @@ final class FormatManager
     private function file(): Path
     {
         $directory = $this->directory();
-        return $directory->join_path('onlyoffice-docs-formats.json');
+        return $directory->joinPath('onlyoffice-docs-formats.json');
     }
 
     private function directory(): Path
     {
-        $current_directory = new Path(__DIR__);
-        return $current_directory
-            ->join_path('..')
-            ->join_path('..')
-            ->join_path('assets')
-            ->join_path('document-formats');
+        $currentDirectory = new Path(__DIR__);
+        return $currentDirectory
+            ->joinPath('..')
+            ->joinPath('..')
+            ->joinPath('assets')
+            ->joinPath('document-formats');
     }
 }

--- a/web/documentserver-example/php/src/format/FormatManagerAllTests.php
+++ b/web/documentserver-example/php/src/format/FormatManagerAllTests.php
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 
+namespace Example\Format\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Format\FormatManager;
 

--- a/web/documentserver-example/php/src/format/FormatManagerConvertibleTests.php
+++ b/web/documentserver-example/php/src/format/FormatManagerConvertibleTests.php
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 
+namespace Example\Format\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Format\FormatManager;
 

--- a/web/documentserver-example/php/src/format/FormatManagerEditableTests.php
+++ b/web/documentserver-example/php/src/format/FormatManagerEditableTests.php
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 
+namespace Example\Format\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Format\FormatManager;
 

--- a/web/documentserver-example/php/src/format/FormatManagerFillableTests.php
+++ b/web/documentserver-example/php/src/format/FormatManagerFillableTests.php
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 
+namespace Example\Format\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Format\FormatManager;
 

--- a/web/documentserver-example/php/src/format/FormatManagerViewableTests.php
+++ b/web/documentserver-example/php/src/format/FormatManagerViewableTests.php
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 
+namespace Example\Format\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Example\Format\FormatManager;
 

--- a/web/documentserver-example/php/src/format/FormatTests.php
+++ b/web/documentserver-example/php/src/format/FormatTests.php
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 
+namespace Example\Format\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;

--- a/web/documentserver-example/php/src/helpers/ExampleUsers.php
+++ b/web/documentserver-example/php/src/helpers/ExampleUsers.php
@@ -22,15 +22,15 @@ use function Example\sendlog;
 
 final class ExampleUsers
 {
-    private array $descr_user_1;
-    private array $descr_user_2;
-    private array $descr_user_3;
-    private array $descr_user_0;
+    private array $user1Description;
+    private array $user2Description;
+    private array $user3Description;
+    private array $user0Description;
     private array $users;
 
     public function __construct()
     {
-        $this->descr_user_1 = [
+        $this->user1Description = [
             "File author by default",
             "Doesn’t belong to any group",
             "Can review all the changes",
@@ -39,16 +39,16 @@ final class ExampleUsers
             "Can create files from templates using data from the editor",
             "Can see the information about all users",
         ];
-        $this->descr_user_2 = [
+        $this->user2Description = [
             "Belongs to Group2",
             "Can review only his own changes or changes made by users with no group",
-            "Can view comments, edit his own comments and comments left by users with no group. 
+            "Can view comments, edit his own comments and comments left by users with no group.
         Can remove his own comments only",
             "This file is marked as favorite",
             "Can create new files from the editor",
             "Can see the information about users from Group2 and users who don’t belong to any group",
         ];
-        $this->descr_user_3 = [
+        $this->user3Description = [
             "Belongs to Group3",
             "Can review changes made by Group2 users",
             "Can view comments left by Group2 and Group3 users. Can edit comments left by the Group2 users",
@@ -59,7 +59,7 @@ final class ExampleUsers
             "Can create new files from the editor",
             "Can see the information about Group2 users",
         ];
-        $this->descr_user_0 = [
+        $this->user0Description = [
             "The name is requested when the editor is opened",
             "Doesn’t belong to any group",
             "Can review all the changes",
@@ -83,7 +83,7 @@ final class ExampleUsers
                 null,
                 null,
                 [],
-                $this->descr_user_1,
+                $this->user1Description,
                 true
             ),
             new Users(
@@ -100,7 +100,7 @@ final class ExampleUsers
                 ["group-2", ""],
                 true,
                 [],
-                $this->descr_user_2,
+                $this->user2Description,
                 false
             ),
             new Users(
@@ -117,7 +117,7 @@ final class ExampleUsers
                 ["group-2"],
                 false,
                 ["copy", "download", "print"],
-                $this->descr_user_3,
+                $this->user3Description,
                 false
             ),
             new Users(
@@ -130,7 +130,7 @@ final class ExampleUsers
                 [],
                 null,
                 ["protect"],
-                $this->descr_user_0,
+                $this->user0Description,
                 false
             ),
         ];

--- a/web/documentserver-example/php/src/helpers/JwtManager.php
+++ b/web/documentserver-example/php/src/helpers/JwtManager.php
@@ -31,8 +31,8 @@ final class JwtManager
      */
     public function isJwtEnabled(): bool
     {
-        $config_manager = new ConfigurationManager();
-        return !empty($config_manager->jwt_secret());
+        $configManager = new ConfigurationManager();
+        return !empty($configManager->jwtSecret());
     }
 
     /**
@@ -42,8 +42,8 @@ final class JwtManager
      */
     public function tokenUseForRequest(): bool
     {
-        $config_manager = new ConfigurationManager();
-        return $config_manager->jwt_use_for_request() ?: false;
+        $configManager = new ConfigurationManager();
+        return $configManager->jwtUseForRequest() ?: false;
     }
 
     /**
@@ -55,8 +55,8 @@ final class JwtManager
      */
     public function jwtEncode($payload)
     {
-        $config_manager = new ConfigurationManager();
-        return JWT::encode($payload, $config_manager->jwt_secret(), 'HS256');
+        $configManager = new ConfigurationManager();
+        return JWT::encode($payload, $configManager->jwtSecret(), 'HS256');
     }
 
     /**
@@ -68,11 +68,11 @@ final class JwtManager
      */
     public function jwtDecode($token)
     {
-        $config_manager = new ConfigurationManager();
+        $configManager = new ConfigurationManager();
         try {
             $payload = JWT::decode(
                 $token,
-                new Key($config_manager->jwt_secret(), 'HS256')
+                new Key($configManager->jwtSecret(), 'HS256')
             );
         } catch (\UnexpectedValueException $e) {
             $payload = "";

--- a/web/documentserver-example/php/src/proxy/ProxyManager.php
+++ b/web/documentserver-example/php/src/proxy/ProxyManager.php
@@ -39,20 +39,20 @@ class ProxyManager
 
     private function referPublicURL(URL $url): bool
     {
-        $public_url = $this->configManager->document_server_public_url();
+        $publicURL = $this->configManager->documentServerPublicURL();
         return
-            $url->scheme() == $public_url->scheme() &&
-            $url->host() == $public_url->host() &&
-            $url->port() == $public_url->port();
+            $url->scheme() == $publicURL->scheme() &&
+            $url->host() == $publicURL->host() &&
+            $url->port() == $publicURL->port();
     }
 
     private function redirectPublicURL(URL $url): URL
     {
-        $private_url = $this->configManager->document_server_private_url();
-        return URL::from_components(
-            $private_url->scheme(),
-            $private_url->host(),
-            $private_url->port(),
+        $privateURL = $this->configManager->documentServerPrivateURL();
+        return URL::fromComponents(
+            $privateURL->scheme(),
+            $privateURL->host(),
+            $privateURL->port(),
             $url->user(),
             $url->pass(),
             $url->path(),

--- a/web/documentserver-example/php/src/proxy/ProxyManagerTests.php
+++ b/web/documentserver-example/php/src/proxy/ProxyManagerTests.php
@@ -15,6 +15,8 @@
 // limitations under the License.
 //
 
+namespace Example\Proxy\Tests;
+
 use Example\Common\URL;
 use PHPUnit\Framework\TestCase;
 use Example\Configuration\ConfigurationManager;
@@ -26,16 +28,16 @@ final class ProxyManagerTests extends TestCase
     {
         $configManager = $this->createStub(ConfigurationManager::class);
         $configManager
-            ->method('document_server_public_url')
+            ->method('documentServerPublicURL')
             ->willReturn(new URL('http://localhost'));
         $configManager
-            ->method('document_server_private_url')
+            ->method('documentServerPrivateURL')
             ->willReturn(new URL('http://proxy'));
 
         $proxyManager = new ProxyManager($configManager);
 
-        $raw_url = 'http://localhost/endpoint?query=string';
-        $url = new URL($raw_url);
+        $rawURL = 'http://localhost/endpoint?query=string';
+        $url = new URL($rawURL);
         $resolvedURL = $proxyManager->resolveURL($url);
 
         $this->assertEquals(
@@ -48,13 +50,13 @@ final class ProxyManagerTests extends TestCase
     {
         $configManager = $this->createStub(ConfigurationManager::class);
         $configManager
-            ->method('document_server_public_url')
+            ->method('documentServerPublicURL')
             ->willReturn(new URL('http://localhost'));
 
         $proxyManager = new ProxyManager($configManager);
 
-        $raw_url = 'http://proxy/endpoint?query=string';
-        $url = new URL($raw_url);
+        $rawURL = 'http://proxy/endpoint?query=string';
+        $url = new URL($rawURL);
         $resolvedURL = $proxyManager->resolveURL($url);
 
         $this->assertEquals(

--- a/web/documentserver-example/php/src/trackmanager.php
+++ b/web/documentserver-example/php/src/trackmanager.php
@@ -30,17 +30,17 @@ use Example\Proxy\ProxyManager;
  */
 function readBody()
 {
-    $config_manager = new ConfigurationManager();
+    $configManager = new ConfigurationManager();
 
     $result["error"] = 0;
     $jwtManager = new JwtManager();
     // get the body of the post request and check if it is correct
-    if (($body_stream = file_get_contents('php://input')) === false) {
+    if (($bodyStream = file_get_contents('php://input')) === false) {
         $result["error"] = "Bad Request";
         return $result;
     }
 
-    $data = json_decode($body_stream, false);
+    $data = json_decode($bodyStream, false);
 
     // check if the response is correct
     if ($data === null) {
@@ -56,7 +56,7 @@ function readBody()
 
         $inHeader = false;
         $data = "";
-        $jwtHeader = $config_manager->jwt_header();
+        $jwtHeader = $configManager->jwtHeader();
 
         if (!empty($data["token"])) {  // if the document token is in the data
             $data = $jwtManager->jwtDecode($data["token"]);  // decode it
@@ -140,7 +140,7 @@ function processSave($rawData, $fileName, $userAddress)
 
     $saved = 1;
 
-    if (!(($new_data = file_get_contents(
+    if (!(($newData = file_get_contents(
         $downloadUri,
         false,
         stream_context_create(["http" => ["timeout" => 5]])
@@ -155,7 +155,7 @@ function processSave($rawData, $fileName, $userAddress)
         // get the path to the previous file version and rename the storage path with it
         rename(getStoragePath($fileName, $userAddress), $verDir .
             DIRECTORY_SEPARATOR . "prev" . $curExt);
-        file_put_contents($storagePath, $new_data, LOCK_EX);  // save file to the storage directory
+        file_put_contents($storagePath, $newData, LOCK_EX);  // save file to the storage directory
 
         if ($changesData = file_get_contents(
             $data->changesurl,
@@ -240,7 +240,7 @@ function processForceSave($data, $fileName, $userAddress)
 
     $saved = 1;
 
-    if (!(($new_data = file_get_contents(
+    if (!(($newData = file_get_contents(
         $downloadUri,
         false,
         stream_context_create(["http" => ["timeout" => 5]])
@@ -268,7 +268,7 @@ function processForceSave($data, $fileName, $userAddress)
             }
         }
 
-        file_put_contents($forcesavePath, $new_data, LOCK_EX);
+        file_put_contents($forcesavePath, $newData, LOCK_EX);
 
         if ($isSubmitForm) {
             $uid = $data->actions[0]->userid;  // get the user id
@@ -294,10 +294,10 @@ function processForceSave($data, $fileName, $userAddress)
  */
 function commandRequest($method, $key, $meta = null)
 {
-    $config_manager = new ConfigurationManager();
+    $configManager = new ConfigurationManager();
 
     $jwtManager = new JwtManager();
-    $documentCommandUrl = $config_manager->document_server_command_url()->string();
+    $documentCommandUrl = $configManager->documentServerCommandURL()->string();
 
     $arr = [
         "c" => $method,
@@ -309,7 +309,7 @@ function commandRequest($method, $key, $meta = null)
     }
 
     $headerToken = "";
-    $jwtHeader = $config_manager->jwt_header();
+    $jwtHeader = $configManager->jwtHeader();
 
     // check if a secret key to generate token exists or not
     if ($jwtManager->isJwtEnabled() && $jwtManager->tokenUseForRequest()) {
@@ -329,15 +329,15 @@ function commandRequest($method, $key, $meta = null)
     ]];
 
     if (mb_substr($documentCommandUrl, 0, mb_strlen("https")) === "https") {
-        if ($config_manager->ssl_verify_peer_mode_enabled()) {
+        if ($configManager->sslVerifyPeerModeEnabled()) {
             $opts['ssl'] = ['verify_peer' => false, 'verify_peer_name' => false];
         }
     }
 
     $context = stream_context_create($opts);
-    $response_data = file_get_contents($documentCommandUrl, false, $context);
+    $responseData = file_get_contents($documentCommandUrl, false, $context);
 
-    return $response_data;
+    return $responseData;
 }
 
 function resolveProcessSaveData($data)

--- a/web/documentserver-example/php/src/views/DocEditorView.php
+++ b/web/documentserver-example/php/src/views/DocEditorView.php
@@ -41,7 +41,7 @@ final class DocEditorView extends View
     {
         parent::__construct($tempName);
 
-        $config_manager = new ConfigurationManager();
+        $configManager = new ConfigurationManager();
         $formatManager = new FormatManager();
 
         $externalUrl = $request["fileUrl"] ?? "";
@@ -63,8 +63,8 @@ final class DocEditorView extends View
             $filename = tryGetDefaultByType($createExt, $user);
 
             // create the demo file url
-            $new_url = "editor?fileID=" . $filename . "&user=" . $request["user"];
-            header('Location: ' . $new_url, true);
+            $newURL = "editor?fileID=" . $filename . "&user=" . $request["user"];
+            header('Location: ' . $newURL, true);
             exit;
         }
 
@@ -267,7 +267,7 @@ final class DocEditorView extends View
         }
         $this->tagsValues = [
             "docType" => getDocumentType($filename),
-            "apiUrl" => $config_manager->document_server_api_url()->string(),
+            "apiUrl" => $configManager->documentServerAPIURL()->string(),
             "dataInsertImage" => mb_strimwidth(
                 json_encode($dataInsertImage),
                 1,

--- a/web/documentserver-example/php/src/views/IndexStoredListView.php
+++ b/web/documentserver-example/php/src/views/IndexStoredListView.php
@@ -86,7 +86,8 @@ class IndexStoredListView extends View
                         $layout .= '<td class="contentCells contentCells-icon">  <a href="editor?fileID='.
                             urlencode($storeFile->name).'&user='.htmlentities($user).$directUrlArg.
                             '&action=filter&type=desktop" target="_blank">'.
-                        '   <img src="assets/images/filter.svg" alt="Open in editor without access to change the filter"'.
+                        '   <img src="assets/images/filter.svg"'.
+                        ' alt="Open in editor without access to change the filter"'.
                         ' title="Open in editor without access to change the filter" /></a></td>';
                     } else {
                         $layout .= '<td class="contentCells  contentCells-icon"></td>';

--- a/web/documentserver-example/php/src/views/IndexView.php
+++ b/web/documentserver-example/php/src/views/IndexView.php
@@ -63,8 +63,8 @@ final class IndexView extends View
     private function getLanguageListOptionsLayout()
     {
         $layout = "";
-        $config_manager = new ConfigurationManager();
-        foreach ($config_manager->languages() as $key => $language) {
+        $configManager = new ConfigurationManager();
+        foreach ($configManager->languages() as $key => $language) {
             $layout .= '<option value="'.$key.'">'.$language.'</option>'.PHP_EOL;
         }
         return $layout;
@@ -102,8 +102,8 @@ final class IndexView extends View
 
     private function getPreloaderUrl()
     {
-        $config_manager = new ConfigurationManager();
-        return $config_manager->document_server_preloader_url()->string();
+        $configManager = new ConfigurationManager();
+        return $configManager->documentServerPreloaderURL()->string();
     }
 
     private function getEditButton()


### PR DESCRIPTION
I corrected errors, but there was one function ([`getResponseUri`](https://github.com/ONLYOFFICE/document-server-integration/blob/94619521a869733ff64263039753ab9e3ebb3083/web/documentserver-example/php/src/functions.php#L772)) that I didn't touch. I don't understand its signature and why the function itself is needed since it isn't used anywhere.