### PR TITLE
make the proxy service dependent on the document-server and example services

### DIFF
--- a/web/documentserver-example/php/docker-compose.yml
+++ b/web/documentserver-example/php/docker-compose.yml
@@ -31,6 +31,9 @@ services:
     build:
       context: .
       target: proxy
+    depends_on:
+      - document-server
+      - example
     ports:
       - "80:80"
       - "8080:8080"

--- a/web/documentserver-example/python/compose-base.yml
+++ b/web/documentserver-example/python/compose-base.yml
@@ -28,6 +28,9 @@ services:
     build:
       context: .
       target: proxy
+    depends_on:
+      - document-server
+      - example
     ports:
       - "80:80"
       - "8080:8080"

--- a/web/documentserver-example/ruby/compose-base.yml
+++ b/web/documentserver-example/ruby/compose-base.yml
@@ -29,6 +29,9 @@ services:
     build:
       context: .
       target: proxy
+    depends_on:
+      - document-server
+      - example
     ports:
       - "80:80"
       - "8080:8080"


### PR DESCRIPTION
Sometimes the proxy service is mounted in front of the document-server or example services, which may cause an error that the latter is unavailable.