### PR TITLE
add example versions

### DIFF
--- a/web/documentserver-example/php/composer.json
+++ b/web/documentserver-example/php/composer.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.6.0",
     "require": {
         "ext-mbstring": "*",
         "firebase/php-jwt": "^6.8.1",

--- a/web/documentserver-example/ruby/example.gemspec
+++ b/web/documentserver-example/ruby/example.gemspec
@@ -1,0 +1,3 @@
+Gem::Specification.new do |s|
+  s.version = "1.6.0"
+end


### PR DESCRIPTION
In the past, example versions were specified in their configuration files. However, from now on, they will be specified in specialized files designed for their respective ecosystems.

A version of the example in Python may be found [here](https://github.com/ONLYOFFICE/document-server-integration/blob/develop/web/documentserver-example/python/pyproject.toml#L8).