### PR TITLE
ruby: use bundler configuration instead of flags

### DIFF
--- a/web/documentserver-example/ruby/.gitignore
+++ b/web/documentserver-example/ruby/.gitignore
@@ -1,3 +1,4 @@
+.bundle
 bin
 db
 log

--- a/web/documentserver-example/ruby/Makefile
+++ b/web/documentserver-example/ruby/Makefile
@@ -22,6 +22,8 @@ help: #          Show help message for each of the Makefile recipes.
 		awk 'BEGIN {FS = ": # "}; {printf "%s: %s\n", $$1, $$2}'
 
 .PHONY: dev
+dev: \
+	export BUNDLE_WITH := development:doc:test
 dev: #           Install development dependencies and initialize the project.
 	@bundle install
 	@bundle exec rake app:update:bin
@@ -30,8 +32,10 @@ ifeq ($(SORBET_SUPPORTED),1)
 endif
 
 .PHONY: prod
+prod: \
+	export BUNDLE_WITHOUT := development:doc:test
 prod: #          Install production dependencies.
-	@bundle install --without development doc test
+	@bundle install
 	@bundle exec rake app:update:bin
 
 .PHONY: server-dev


### PR DESCRIPTION
Starting from version 2.1 (the latest is 2.4), Bundler [is deprecating the use of CLI options](https://bundler.io/v2.1/whats_new.html#cli-deprecations) known as `--` flags. In this request, I'm replacing these options with environment variables to resolve warnings and keep us safe in the future when transitioning to version 3 of Bundler.