### PR TITLE
fix/php-get-stored-files

### DIFF
--- a/web/documentserver-example/php/src/functions.php
+++ b/web/documentserver-example/php/src/functions.php
@@ -353,12 +353,13 @@ function getStoredFiles()
 
     $cdir = scandir($directory);  // get all the files and folders from the directory
     $result = [];
+    $index = 0;
     foreach ($cdir as $key => $fileName) {  // run through all the file and folder names
         if (!in_array($fileName, [".", ".."])) {
             if (!is_dir($directory . DIRECTORY_SEPARATOR . $fileName)) {  // if an element isn't a directory
                 $ext = mb_strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
                 $dat = filemtime($directory . DIRECTORY_SEPARATOR . $fileName);  // get the time of element modification
-                $result[$dat] = (object) [  // and write the file to the result
+                $result[$dat + $index++] = (object) [  // and write the file to the result
                     "name" => $fileName,
                     "documentType" => getDocumentType($fileName),
                     "canEdit" => in_array($ext, $formatManager->editableExtensions()),


### PR DESCRIPTION
In the getStoredFiles function, when creating an array of stored files, the file creation date is used as the key. If there are 2 files with the same creation date, the element in the array is overwritten.