### PR TITLE
Convert after uploading only tagged formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- csharp-mvc: convert after uploading only tagged formats
 - link in referenceData
 - using a repo with a list of formats
 - ruby: convert after uploading only tagged formats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- csharp: convert after uploading only tagged formats
 - csharp-mvc: convert after uploading only tagged formats
 - link in referenceData
 - using a repo with a list of formats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 # Change Log
 
-- csharp: convert after uploading only tagged formats
-- csharp-mvc: convert after uploading only tagged formats
-- link in referenceData
 - using a repo with a list of formats
-- ruby: convert after uploading only tagged formats
-- python: convert after uploading only tagged formats
-- php: convert after uploading only tagged formats
+- convert after uploading only tagged formats
+- link in referenceData
 - setUsers for region protection
 - onRequestOpen method
 - user avatar

--- a/web/documentserver-example/csharp-mvc/Models/FileUtility.cs
+++ b/web/documentserver-example/csharp-mvc/Models/FileUtility.cs
@@ -126,9 +126,7 @@ namespace OnlineEditorsExampleMVC.Models
         public static List<Format> Convertible()
         {
             return All()
-                .Where(format => (format.Type == FileType.Cell && format.Convert.Contains("xlsx"))
-                                || (format.Type == FileType.Slide && format.Convert.Contains("pptx"))
-                                || (format.Type == FileType.Word && format.Convert.Contains("docx")))
+                .Where(format => format.Actions.Contains("auto-convert"))
                 .ToList();
         }
 

--- a/web/documentserver-example/csharp/FormatManager.cs
+++ b/web/documentserver-example/csharp/FormatManager.cs
@@ -104,9 +104,7 @@ namespace OnlineEditorsExample
         public static List<Format> Convertible()
         {
             return All()
-                .Where(format => (format.Type == "cell" && format.Convert.Contains("xlsx"))
-                                || (format.Type == "slide" && format.Convert.Contains("pptx"))
-                                || (format.Type == "word" && format.Convert.Contains("docx")))
+                .Where(format => format.Actions.Contains("auto-convert"))
                 .ToList();
         }
 


### PR DESCRIPTION
In csharp-mvc, csharp: getting list of convertible extensions(for automatic convert after upload) from 'document-formats', where "auto-convert" is present in 'actions' field.
