### PR TITLE
node: fixed overflow when hashing сyrillic characters

### DIFF
--- a/web/documentserver-example/nodejs/app.js
+++ b/web/documentserver-example/nodejs/app.js
@@ -55,7 +55,7 @@ String.prototype.hashCode = function hashCode() {
   const len = this.length;
   let ret = 0;
   for (let i = 0; i < len; i++) {
-    ret = Math.trunc(31 * ret + this.charCodeAt(i));
+    ret = Math.imul(ret, 31) + this.charCodeAt(i);
   }
   return ret;
 };


### PR DESCRIPTION
charCodeAt for сyrillic returns a four digit number. The variable overflows, so the key is always the same for сyrillic files.