### PR TITLE
fix(php): correct sendNotify agrument

### DIFF
--- a/web/documentserver-example/php/templates/docEditor.tpl
+++ b/web/documentserver-example/php/templates/docEditor.tpl
@@ -310,7 +310,7 @@
         var onRequestSendNotify = function (event) {
             event.data.actionLink = replaceActionLink(location.href, JSON.stringify(event.data.actionLink));
             var data = JSON.stringify(event.data);
-            innerAlert(\"onRequestSendNotify: \" + data);
+            innerAlert("onRequestSendNotify: " + data);
         };
 
         var сonnectEditor = function () {


### PR DESCRIPTION
Php example bugfix. The editor did not open due to an incorrect argument in onrequestSendNotify.