### PR TITLE
Fix/compose prod

### DIFF
--- a/web/documentserver-example/python/Dockerfile
+++ b/web/documentserver-example/python/Dockerfile
@@ -13,7 +13,7 @@ CMD ["make", "server-dev"]
 
 FROM example-base AS example-prod
 RUN make prod
-CMD ["make", "server-prod"]
+CMD ["make", "server-dev"]
 
 FROM nginx:1.23.4-alpine3.17 AS proxy
 COPY proxy/nginx.conf /etc/nginx/nginx.conf

--- a/web/documentserver-example/ruby/Dockerfile
+++ b/web/documentserver-example/ruby/Dockerfile
@@ -16,7 +16,7 @@ RUN make dev
 CMD ["make", "server-dev"]
 
 FROM example-base AS example-prod
-RUN make prod
+RUN make dev
 CMD ["make", "server-prod"]
 
 FROM nginx:1.23.4-alpine3.17 AS proxy


### PR DESCRIPTION
Ruby example doesn't start in prod container because bundler looks for dev dependencies.
Python example starts on 0.0.0.0 port in prod container and some endpoints are broken. For example static images, styles and scripts.